### PR TITLE
add support for vertically scrolling textboxes

### DIFF
--- a/Material.Demo/Pages/FieldsDemo.axaml
+++ b/Material.Demo/Pages/FieldsDemo.axaml
@@ -65,7 +65,7 @@
                         </Style>
                     </StackPanel.Styles>
                     <showMeTheXaml:XamlDisplay UniqueId="MultilineFields0">
-                        <TextBox Classes="Floating" AcceptsReturn="True" TextWrapping="Wrap"
+                        <TextBox Classes="Floating" AcceptsReturn="True" MaxHeight="100" TextWrapping="Wrap" wpf:TextFieldAssist.Label="Multiline Test" UseFloatingWatermark="True"
                                  Text="Multiline. Lorem ipsum dolor sit amet, consectetur 
  adipiscing elit, sed do eiusmod tempor incididunt ut labore
  et dolore magna aliqua. The quick brown fox jumps over the 
@@ -159,6 +159,7 @@
                                  Classes="Filled"
                                  AcceptsReturn="True"
                                  TextWrapping="Wrap"
+                                 MaxHeight="100"
                                  Text="Multiline. Lorem ipsum dolor sit amet, consectetur 
  adipiscing elit, sed do eiusmod tempor incididunt ut labore
  et dolore magna aliqua. The quick brown fox jumps over the 
@@ -244,6 +245,7 @@
                         <TextBox UseFloatingWatermark="True"
                                  wpf:TextFieldAssist.Label="Multiline textfield"
                                  Classes="Outline"
+                                 MaxHeight="100"
                                  AcceptsReturn="True"
                                  TextWrapping="Wrap"
                                  Text="Multiline. Lorem ipsum dolor sit amet, consectetur 

--- a/Material.Styles/ScrollBar.xaml
+++ b/Material.Styles/ScrollBar.xaml
@@ -206,7 +206,6 @@
         <Setter Property="Template">
             <ControlTemplate>
                 <Grid Name="rootGrid"
-                      Margin="3,12"
                       Width="6">
                     <Border Name="backBorder"
                             CornerRadius="6"
@@ -275,6 +274,13 @@
             <Transitions>
                 <DoubleTransition Duration="0:0:0.5" Property="Opacity" Easing="CubicEaseOut" />
             </Transitions>
+        </Setter>
+    </Style>
+
+    <!-- Allow overriding from TextBox -->
+    <Style Selector="ScrollBar.Modern /template/ Grid#rootGrid">
+        <Setter Property="Margin"
+                Value="3 12">
         </Setter>
     </Style>
 

--- a/Material.Styles/TextBox.xaml
+++ b/Material.Styles/TextBox.xaml
@@ -58,8 +58,9 @@
             Noto Sans TC, Noto Sans SC, Noto Sans JP, Noto Sans KR, Noto Sans, Arial"/>
         <Setter Property="Template">
             <ControlTemplate>
-                <StackPanel>
+                <Grid RowDefinitions="*, Auto">
                     <Border Name="PART_RootBorder" Cursor="Ibeam"
+                            Grid.Row="0"
                             Background="{TemplateBinding Background}"
                             BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}">
@@ -89,10 +90,11 @@
                             <DataValidationErrors Name="DataValidation">
                                 <Grid ColumnDefinitions="Auto,*,Auto">
                                     <ContentPresenter Grid.Column="0" Content="{TemplateBinding InnerLeftContent}" />
-                                    <ScrollViewer Grid.Column="1"
+                                    <Panel Grid.Column="1" Name="PART_TextRoot">
+                                        <ScrollViewer Name="PART_Scroller"
                                                   HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
                                                   VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}">
-                                        <Panel Name="PART_TextRoot" VerticalAlignment="Bottom">
+                                        <Panel>
                                             <TextBlock Name="watermark"
                                                        Margin="0,6,0,7"
                                                        Classes="Subtitle1"
@@ -116,8 +118,9 @@
                                                            SelectionBrush="{TemplateBinding SelectionBrush}"
                                                            SelectionForegroundBrush="{TemplateBinding SelectionForegroundBrush}"
                                                            CaretBrush="{TemplateBinding CaretBrush}" />
-                                        </Panel>
+                                       </Panel>
                                     </ScrollViewer>
+                                    </Panel>
                                     <ContentPresenter Grid.Column="2" Content="{TemplateBinding InnerRightContent}" />
                                     <styles:MaterialUnderline Grid.ColumnSpan="3" Classes="MirrorY"
                                                               VerticalAlignment="Bottom"
@@ -126,9 +129,9 @@
                             </DataValidationErrors>
                         </Grid>
                     </Border>
-                    <TextBlock Name="HintsTextBlock" Classes="Caption" Margin="0,3,0,0"
+                    <TextBlock Grid.Row="1" Name="HintsTextBlock" Classes="Caption" Margin="0,3,0,0"
                                Text="{TemplateBinding (wpf:TextFieldAssist.Hints)}" TextTrimming="CharacterEllipsis" />
-                </StackPanel>
+                </Grid>
             </ControlTemplate>
         </Setter>
     </Style>
@@ -166,6 +169,11 @@
     
     <Style Selector="TextBox /template/ TextBlock#floatingWatermark">
         <Setter Property="Foreground" Value="{DynamicResource ThemeAccentBrush}"/>
+    </Style>
+
+    <Style Selector="TextBox /template/ #PART_Scroller /template/ ScrollBar.Modern /template/ Grid#rootGrid">
+        <Setter Property="Margin"
+                Value="0 8 0 4"/>
     </Style>
     
     <!-- Default TextBox style -->
@@ -216,8 +224,8 @@
         <Setter Property="CaretBrush" Value="{Binding RelativeSource={RelativeSource Self}, Path=Foreground}" />
         <Setter Property="Template">
             <ControlTemplate>
-                <StackPanel>
-                    <DataValidationErrors Name="DataValidation">
+                <Grid RowDefinitions="*, Auto">
+                    <DataValidationErrors Grid.Row="0" Name="DataValidation">
                         <Border Name="PART_RootBorder" Cursor="Ibeam"
                                 ClipToBounds="True" CornerRadius="4,4,0,0"
                                 Background="{TemplateBinding Background}"
@@ -235,10 +243,11 @@
 
                                 <Grid ColumnDefinitions="Auto,*,Auto">
                                     <ContentPresenter Grid.Column="0" Content="{TemplateBinding InnerLeftContent}" />
-                                    <ScrollViewer Name="PART_Scroller" Grid.Column="1" Classes="Modern" Padding="16,0"
-                                                  HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
-                                                  VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}">
-                                        <Panel Name="PART_TextRoot">
+                                    <Panel Name="PART_TextRoot" Grid.Column="1">
+                                        <ScrollViewer Name="PART_Scroller" Classes="Modern" Padding="16,0"
+                                                      HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
+                                                      VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}">
+                                        <Panel>
                                             <TextBlock Name="watermark"
                                                        Classes="Subtitle1" Opacity="0.5"
                                                        Text="{TemplateBinding Watermark}"
@@ -262,6 +271,7 @@
                                                            CaretBrush="{TemplateBinding CaretBrush}" />
                                         </Panel>
                                     </ScrollViewer>
+                                    </Panel>
                                     <ContentPresenter Grid.Column="2" Content="{TemplateBinding InnerRightContent}" />
                                     <styles:MaterialUnderline Grid.ColumnSpan="3" Classes="MirrorY"
                                                               VerticalAlignment="Bottom"
@@ -271,9 +281,9 @@
                             </Grid>
                         </Border>
                     </DataValidationErrors>
-                    <TextBlock Name="HintsTextBlock" Classes="Caption" Margin="0,3,0,0"
+                    <TextBlock Grid.Row="1" Name="HintsTextBlock" Classes="Caption" Margin="0,3,0,0"
                                Text="{TemplateBinding (wpf:TextFieldAssist.Hints)}" TextTrimming="CharacterEllipsis" />
-                </StackPanel>
+                </Grid>
             </ControlTemplate>
         </Setter>
     </Style>
@@ -302,6 +312,11 @@
     
     <Style Selector="TextBox.Filled /template/ Panel#PART_TextRoot">
         <Setter Property="Margin" Value="0,24,0,6"/>
+    </Style>
+
+    <Style Selector="TextBox.Filled /template/ #PART_Scroller /template/ ScrollBar.Modern /template/ Grid#rootGrid">
+        <Setter Property="Margin"
+                Value="0"/>
     </Style>
     
     <Style Selector="TextBox.Filled[UseFloatingWatermark=False] /template/ Panel#PART_TextRoot">
@@ -347,8 +362,8 @@
         <Setter Property="CaretBrush" Value="{Binding RelativeSource={RelativeSource Self}, Path=Foreground}" />
         <Setter Property="Template">
             <ControlTemplate>
-                <StackPanel>
-                    <DataValidationErrors Name="DataValidation">
+                <Grid RowDefinitions="*, Auto">
+                    <DataValidationErrors Grid.Row="0" Name="DataValidation">
                         <Grid Name="PART_RootBorder"
                               HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
                               Cursor="Ibeam" Background="Transparent"
@@ -378,12 +393,12 @@
 
                             <Grid ColumnDefinitions="Auto,*,Auto">
                                 <ContentPresenter Grid.Column="0" Content="{TemplateBinding InnerLeftContent}" />
-                                <ScrollViewer Name="PART_Scroller" Grid.Column="1" Classes="Modern"
-                                              Padding="16, 0, 8,0"
-                                              HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
-                                              VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}">
-                                    <Panel Name="PART_TextRoot"
-                                           VerticalAlignment="Center">
+                                <Panel Grid.Column="1" Name="PART_TextRoot">
+                                    <ScrollViewer Name="PART_Scroller"  Classes="Modern"
+                                                  Padding="16, 0, 8,0"
+                                                  HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
+                                                  VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}">
+                                    <Panel VerticalAlignment="Center">
                                         <TextBlock Name="watermark"
                                                    Classes="Subtitle1" Opacity="0.5"
                                                    Text="{TemplateBinding Watermark}"
@@ -407,14 +422,15 @@
                                                        CaretBrush="{TemplateBinding CaretBrush}" />
                                     </Panel>
                                 </ScrollViewer>
+                                </Panel>
                                 <ContentPresenter Grid.Column="2" Content="{TemplateBinding InnerRightContent}" />
                             </Grid>
 
                         </Grid>
                     </DataValidationErrors>
-                    <TextBlock Name="HintsTextBlock" Classes="Caption" Margin="0,3,0,0"
+                    <TextBlock Grid.Row="1" Name="HintsTextBlock" Classes="Caption" Margin="0,3,0,0"
                                Text="{TemplateBinding (wpf:TextFieldAssist.Hints)}" TextTrimming="CharacterEllipsis" />
-                </StackPanel>
+                </Grid>
             </ControlTemplate>
         </Setter>
     </Style>
@@ -450,7 +466,7 @@
     </Style>
     
     <Style Selector="TextBox.Outline /template/ Panel#PART_TextRoot">
-        <Setter Property="Margin" Value="0,14"/>
+        <Setter Property="Margin" Value="0,14 0 6"/>
         <Setter Property="VerticalAlignment" Value="Center"/>
     </Style>
     
@@ -582,7 +598,7 @@
                             <Grid ColumnDefinitions="Auto,*,Auto">
                                 <ContentPresenter Grid.Column="0" Content="{TemplateBinding InnerLeftContent}" />
                                 <Grid Name="PART_InnerRoot" Grid.Column="1">
-                                    <ScrollViewer HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
+                                    <ScrollViewer Name="PART_Scroller" HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
                                                   VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}">
                                     <Panel Name="PART_TextRoot" VerticalAlignment="Center">
                                         <TextBlock Name="watermark" Classes="Subtitle1" Opacity="0.5"


### PR DESCRIPTION
I just started using this and noticed that if I tried to use a textbox with a fixed height I'd get something like this:
![image](https://user-images.githubusercontent.com/4575355/136688913-4f2e1ce7-0f16-4a17-8a7f-fb023c833560.png)
max height of the TextBox is set to 90. As you can see the text is cut off because it's too long for the space, however there's also no scroll bars. That's what this change attempts to fix. 

Here's the result: 
![image](https://user-images.githubusercontent.com/4575355/136689067-b1bee471-c63e-4097-9968-8644c0ceca30.png)


and here's a sample for each of the 3 main styles:
![image](https://user-images.githubusercontent.com/4575355/136689003-f422f587-2785-4ccc-8bbf-354735248052.png)

I didn't really style the scrollbars just used what was already there, I did make some adjustments to the margin of the scroll bar otherwise it would be really short in some cases due to too much padding. Let me know any issues or improvements that can be made.