### PR TITLE
allow the alignment of the snackbar to be configured

### DIFF
--- a/Material.Styles/SnackbarHost.xaml
+++ b/Material.Styles/SnackbarHost.xaml
@@ -15,7 +15,7 @@
         <Panel>
           <ContentPresenter Content="{TemplateBinding Content}"
                             ContentTemplate="{TemplateBinding ContentTemplate}" />
-          <ItemsControl HorizontalAlignment="Left" VerticalAlignment="Bottom"
+          <ItemsControl HorizontalAlignment="{TemplateBinding SnackbarHorizontalAlignment}" VerticalAlignment="{TemplateBinding SnackbarVerticalAlignment}"
                         Items="{CompiledBinding $parent[cc:SnackbarHost].SnackbarModels}">
             <ItemsControl.ItemsPanel>
               <ItemsPanelTemplate>

--- a/Material.Styles/SnackbarHost.xaml.cs
+++ b/Material.Styles/SnackbarHost.xaml.cs
@@ -8,6 +8,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.LogicalTree;
 using Avalonia.Controls.Primitives;
+using Avalonia.Layout;
 using Avalonia.Threading;
 using Material.Styles.Models;
 
@@ -37,6 +38,24 @@ namespace Material.Styles
 
         public static readonly StyledProperty<string> HostNameProperty =
             AvaloniaProperty.Register<SnackbarHost, string>(nameof(HostName));
+
+        public HorizontalAlignment SnackbarHorizontalAlignment
+        {
+            get => GetValue(SnackbarHorizontalAlignmentProperty);
+            set => SetValue(SnackbarHorizontalAlignmentProperty, value);
+        }
+
+        public static readonly StyledProperty<HorizontalAlignment> SnackbarHorizontalAlignmentProperty =
+            AvaloniaProperty.Register<SnackbarHost, HorizontalAlignment>(nameof(SnackbarHorizontalAlignment), HorizontalAlignment.Left);
+
+        public VerticalAlignment SnackbarVerticalAlignment
+        {
+            get => GetValue(SnackbarVerticalAlignmentProperty);
+            set => SetValue(SnackbarVerticalAlignmentProperty, value);
+        }
+
+        public static readonly StyledProperty<VerticalAlignment> SnackbarVerticalAlignmentProperty =
+            AvaloniaProperty.Register<SnackbarHost, VerticalAlignment>(nameof(SnackbarVerticalAlignment), VerticalAlignment.Bottom);
 
         static SnackbarHost()
         {


### PR DESCRIPTION
I've added some styled properties to SnackbarHost to allow specifying the alignment of the snackbar. By default it's in the bottom left but this will allow a user to move it around, for example to the bottom right, or top center.