### PR TITLE
Renaming ViewModelBase => DialogViewModelBase

### DIFF
--- a/Material.Dialog/ViewModels/DialogWindowViewModel.cs
+++ b/Material.Dialog/ViewModels/DialogWindowViewModel.cs
@@ -9,7 +9,7 @@ using Avalonia.Layout;
 
 namespace Material.Dialog.ViewModels
 {
-    public abstract class DialogWindowViewModel : ViewModelBase
+    public abstract class DialogWindowViewModel : DialogViewModelBase
     {
         #region Base Properties
         private string m_WindowTitle;

--- a/Material.Dialog/ViewModels/TextField/TextFieldViewModel.cs
+++ b/Material.Dialog/ViewModels/TextField/TextFieldViewModel.cs
@@ -7,7 +7,7 @@ using Avalonia.Data;
 
 namespace Material.Dialog.ViewModels.TextField
 {
-    public class TextFieldViewModel : ViewModelBase
+    public class TextFieldViewModel : DialogViewModelBase
     {
         public event EventHandler<bool> OnValidateRequired;
 

--- a/Material.Dialog/ViewModels/ViewModelBase.cs
+++ b/Material.Dialog/ViewModels/ViewModelBase.cs
@@ -1,9 +1,9 @@
 ﻿using System.ComponentModel;
-using System.Runtime.CompilerServices; 
+using System.Runtime.CompilerServices;
 
-namespace Material.Dialog
+namespace Material.Dialog.ViewModels
 {
-    public class ViewModelBase : INotifyPropertyChanged
+    public class DialogViewModelBase : INotifyPropertyChanged
     {
         public event PropertyChangedEventHandler PropertyChanged;
 


### PR DESCRIPTION
This PR is really simple, it just renames the:

Material.Dialog.ViewModels.ViewModelBase => Material.Dialog.ViewModels.DialogViewModelBase

So it does not conflict with the local ViewModelBase