### PR TITLE
Separator background fixed

### DIFF
--- a/Material.Styles/Separator.xaml
+++ b/Material.Styles/Separator.xaml
@@ -8,7 +8,7 @@
         <Setter Property="Margin" Value="0,8"/>
         <Setter Property="Template">
             <ControlTemplate>
-                <Border Background="{TemplateBinding Background}">
+                <Border Background="{TemplateBinding Background}" BorderThickness="0">
                     <Rectangle Height="1" Fill="{TemplateBinding BorderBrush}"
                                HorizontalAlignment="Stretch" VerticalAlignment="Center" />
                 </Border>

--- a/Material.Styles/Separator.xaml
+++ b/Material.Styles/Separator.xaml
@@ -1,15 +1,17 @@
 <Styles xmlns="https://github.com/avaloniaui">
 
     <Style Selector="Separator">
-        <Setter Property="Background" Value="{DynamicResource MaterialDesignSelection}" />
+        <Setter Property="Background" Value="Transparent"/>
         <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignSelection}" />
         <Setter Property="MinHeight" Value="1" />
         <Setter Property="Height" Value="1" />
         <Setter Property="Margin" Value="0,8"/>
         <Setter Property="Template">
             <ControlTemplate>
-                <Rectangle Height="1" Fill="{TemplateBinding Background}"
-                           HorizontalAlignment="Stretch" VerticalAlignment="Center" />
+                <Border Background="{TemplateBinding Background}">
+                    <Rectangle Height="1" Fill="{TemplateBinding BorderBrush}"
+                               HorizontalAlignment="Stretch" VerticalAlignment="Center" />
+                </Border>
             </ControlTemplate>
         </Setter>
     </Style>


### PR DESCRIPTION
`Separator` had wrong background binding and all was filled with `MaterialDesignSelection`. Also now `Rectangle` takes color from `BorderBrush`

Before (no green):
![image](https://user-images.githubusercontent.com/7500203/148760881-b2b1dd24-e2b5-4fa7-9f0f-41abc4200353.png)

After:
![image](https://user-images.githubusercontent.com/7500203/148761140-b4ca4a9a-63e9-4cc6-836e-736d36411892.png)

Final:
![image](https://user-images.githubusercontent.com/7500203/148761426-cb73b05c-6a1f-4eeb-87de-2cdc6c5ade91.png)

