### PR TITLE
Stop Spinner from rotating when hidden.

### DIFF
--- a/Material.Styles/ProgressBar.xaml
+++ b/Material.Styles/ProgressBar.xaml
@@ -324,10 +324,13 @@
     <Style Selector="ProgressBar.Circle:not(:indeterminate) /template/ controls|Rotator#PART_Rotator,
                      ProgressBar.Circle[IsVisible=false] /template/ controls|Rotator#PART_Rotator">
         <Style.Animations>
-            <Animation Duration="0:0:0.1" IterationCount="1">
+            <Animation Duration="0:0:0.1" IterationCount="INFINITE">
                 <KeyFrame Cue="0%">
                     <Setter Property="Speed" Value="0" />
                 </KeyFrame>
+                <KeyFrame Cue="100%">
+	            <Setter Property="Speed" Value="0" />
+		</KeyFrame>
             </Animation>
         </Style.Animations>
     </Style>


### PR DESCRIPTION
Seems the currently used style does not stop the Rotator#PART_Rotator from rotating when IsIndeterminate="True". Found this using GPU resources in the background despite not being on screen. This fixes that by updating that current animation to override the Speed property for the entire duration of animation, forever.