### PR TITLE
SideSheet: Possibility to define a header added with the corresponding properties.

### DIFF
--- a/Material.Demo/Models/SideSheetDemoViewModel.cs
+++ b/Material.Demo/Models/SideSheetDemoViewModel.cs
@@ -5,6 +5,10 @@
     {
         private string _header = "SideSheet";
         public string Header => _header;
+
+        public string ContentHeader { get; set; } = "What is Lorem Ipsum?";
+        
+        public string ImportantInfos { get; set; } = "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.";
     }
     
     // Data context for SideSheet demo page

--- a/Material.Demo/Pages/SideSheetDemo.axaml
+++ b/Material.Demo/Pages/SideSheetDemo.axaml
@@ -6,41 +6,39 @@
              xmlns:pages="clr-namespace:Material.Demo.Pages"
              xmlns:models="clr-namespace:Material.Demo.Models"
              xmlns:avalonia="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
-             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             mc:Ignorable="d" d:DesignWidth="500" d:DesignHeight="450"
              x:Class="Material.Demo.Pages.SideSheetDemo"
              x:DataType="models:SideSheetDemoViewModel">
     <UserControl.DataContext>
-        <models:SideSheetDemoViewModel/>
+        <models:SideSheetDemoViewModel />
     </UserControl.DataContext>
-    
+
     <StackPanel Margin="16, 0">
         <TextBlock Classes="Headline4 Subheadline" Text="Side sheets" />
-        
-        <styles:SideSheet Width="800" Height="560" BorderBrush="Black" BorderThickness="1"
-                          SideSheetDirection="Right"
-                          SideSheetOpened="{CompiledBinding SideInfoOpened}"
-                          SideSheetContent="{CompiledBinding Information}">
+
+        <styles:SideSheet
+            Name="SideSheet"
+            Width="500" Height="560" BorderBrush="Black" BorderThickness="1"
+            SideSheetDirection="Right"
+            SideSheetOpened="{CompiledBinding SideInfoOpened}"
+            SideSheetContent="{CompiledBinding Information}"
+            SideSheetHeader="{CompiledBinding Information.Header}">
             <styles:SideSheet.SideSheetContentTemplate>
                 <DataTemplate DataType="models:SideSheetData">
-                    <Panel Margin="20">
-                        <StackPanel>
-                            <TextBlock Classes="Headline5" Text="{CompiledBinding Header}"/>
-                        </StackPanel>
-                        <Button Classes="Icon" Width="36" Height="36" Margin="-8"
-                                HorizontalAlignment="Right"
-                                VerticalAlignment="Top"
-                                Content="{avalonia:MaterialIconExt Close, Size=20}"
-                                Click="CloseSideInfoButton_OnClick"/>
-                    </Panel>
+                    <StackPanel>
+                        <TextBlock Classes="Headline6" Text="{CompiledBinding ContentHeader}"/>
+                        <TextBlock Text="{CompiledBinding ImportantInfos}" TextWrapping="Wrap"></TextBlock>
+                    </StackPanel>
                 </DataTemplate>
             </styles:SideSheet.SideSheetContentTemplate>
             <Panel>
-                <pages:Home/>
+                <pages:Home />
                 <Button Classes="Icon" Width="36" Height="36"
                         HorizontalAlignment="Right"
                         VerticalAlignment="Top"
                         Content="{avalonia:MaterialIconExt MenuOpen, Size=20}"
-                        Click="OpenSideInfoButton_OnClick"/>
+                        IsVisible="{Binding !#SideSheet.SideSheetOpened}"
+                        Click="OpenSideInfoButton_OnClick" />
             </Panel>
         </styles:SideSheet>
     </StackPanel>

--- a/Material.Styles/SideSheet.xaml
+++ b/Material.Styles/SideSheet.xaml
@@ -2,21 +2,29 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:cc="clr-namespace:Material.Styles"
         xmlns:converters="clr-namespace:Material.Styles.Converters"
-        xmlns:parameters="clr-namespace:Material.Styles.Converters.Parameters">
+        xmlns:parameters="clr-namespace:Material.Styles.Converters.Parameters"
+        xmlns:controls="clr-namespace:Material.Styles.Controls">
     <Styles.Resources>
-        <SineEaseInOut x:Key="EasingConstant"/>
-        
-        <parameters:MarginMultiplyParameter x:Key="LeftMarginCreatorParam" LeftMultiplier="-1"/>
-        <parameters:MarginMultiplyParameter x:Key="RightMarginCreatorParam" RightMultiplier="-1"/>
-        
+        <SineEaseInOut x:Key="EasingConstant" />
+
+        <parameters:MarginMultiplyParameter x:Key="LeftMarginCreatorParam" LeftMultiplier="-1" />
+        <parameters:MarginMultiplyParameter x:Key="RightMarginCreatorParam" RightMultiplier="-1" />
+
         <converters:MarginMultiplyConverter x:Key="MarginCreator" />
     </Styles.Resources>
 
     <!-- SideSheet (desktop variant) -->
     <Style Selector="cc|SideSheet">
         <Setter Property="SideSheetWidth" Value="320" />
-        <Setter Property="SideSheetDirection" Value="Right"/>
+        <Setter Property="SideSheetPadding" Value="16"/>
+        <Setter Property="Padding" Value="0"/>
+        <Setter Property="SideSheetDirection" Value="Right" />
         <Setter Property="Background" Value="{DynamicResource MaterialDesignPaper}" />
+        <Setter Property="SideSheetHeaderTemplate">
+            <DataTemplate>
+                <TextBlock Classes="Headline6" Text="{Binding}"/>
+            </DataTemplate>
+        </Setter>
         <Setter Property="Template">
             <ControlTemplate>
                 <Border Name="PART_RootBorder" ClipToBounds="False"
@@ -26,28 +34,45 @@
                     <DockPanel HorizontalAlignment="Stretch"
                                VerticalAlignment="Stretch">
                         <Border Name="PART_SideSheet"
-                                Width="{TemplateBinding SideSheetWidth}">
-                            <ContentPresenter Content="{TemplateBinding SideSheetContent}"
-                                              ContentTemplate="{TemplateBinding SideSheetContentTemplate}"
-                                              IsEnabled="{TemplateBinding SideSheetOpened}" />
+                                Width="{TemplateBinding SideSheetWidth}"
+                                Padding="{TemplateBinding SideSheetPadding}">
+                            <Grid RowDefinitions="auto,5,*">
+                                <Grid Grid.Row="0" ColumnDefinitions="*,Auto">
+                                    <ContentPresenter
+                                        Grid.Column="0"
+                                        HorizontalAlignment="Left"
+                                        VerticalAlignment="Center"
+                                        Content="{TemplateBinding SideSheetHeader, Mode=OneWay}"
+                                        ContentTemplate="{TemplateBinding SideSheetHeaderTemplate}"
+                                        TextBlock.Foreground="{DynamicResource ThemeForegroundBrush}"/>
+                                    <Button Grid.Column="1" Classes="Icon" Name="PART_CloseButton" IsVisible="{TemplateBinding SideSheetCanClose}">
+                                        <controls:MaterialInternalIcon Kind="Close"/>
+                                    </Button>
+                                </Grid>
+                                <ContentPresenter
+                                    Grid.Row="2"
+                                    Content="{TemplateBinding SideSheetContent}"
+                                    ContentTemplate="{TemplateBinding SideSheetContentTemplate}"
+                                    IsEnabled="{TemplateBinding SideSheetOpened}" />
+                            </Grid>
                         </Border>
                         <Panel Name="PART_ContentPanel">
                             <ContentPresenter Name="ContentPresenter"
                                               Margin="{TemplateBinding Padding}"
                                               Content="{TemplateBinding Content}"
-                                              ContentTemplate="{TemplateBinding ContentTemplate}"/>
+                                              ContentTemplate="{TemplateBinding ContentTemplate}" />
                             <Border Name="PART_Scrim"
                                     Background="Black"
                                     IsHitTestVisible="{TemplateBinding SideSheetOpened}"
                                     HorizontalAlignment="Stretch"
-                                    VerticalAlignment="Stretch"/>
+                                    VerticalAlignment="Stretch" />
                         </Panel>
                     </DockPanel>
                 </Border>
             </ControlTemplate>
         </Setter>
     </Style>
-    
+
     <Style Selector="cc|SideSheet:not(.notransitions) /template/ Border#PART_Scrim">
         <Setter Property="Transitions">
             <Transitions>
@@ -55,7 +80,7 @@
             </Transitions>
         </Setter>
     </Style>
-    
+
     <Style Selector="cc|SideSheet:not(.notransitions) /template/ Border#PART_SideSheet">
         <Setter Property="Transitions">
             <Transitions>
@@ -67,70 +92,71 @@
     <Style Selector="cc|SideSheet /template/ Border#PART_Scrim">
         <Setter Property="Opacity" Value="0" />
     </Style>
-    
+
     <Style Selector="cc|SideSheet:left:closed /template/ Border#PART_SideSheet">
         <Setter Property="Margin"
                 Value="{Binding $self.Width, 
                 Converter={StaticResource MarginCreator}, 
-                ConverterParameter={StaticResource LeftMarginCreatorParam}}"/>
+                ConverterParameter={StaticResource LeftMarginCreatorParam}}" />
     </Style>
-    
+
     <Style Selector="cc|SideSheet:left /template/ Border#PART_ContentPanel">
-        <Setter Property="DockPanel.Dock" Value="Left"/>
+        <Setter Property="DockPanel.Dock" Value="Left" />
     </Style>
-    
+
     <Style Selector="cc|SideSheet:right:closed /template/ Border#PART_SideSheet">
         <Setter Property="Margin"
                 Value="{Binding $self.Width, 
                 Converter={StaticResource MarginCreator}, 
-                ConverterParameter={StaticResource RightMarginCreatorParam}}"/>
+                ConverterParameter={StaticResource RightMarginCreatorParam}}" />
     </Style>
-    
+
     <Style Selector="cc|SideSheet:right /template/ Border#PART_ContentPanel">
-        <Setter Property="DockPanel.Dock" Value="Right"/>
+        <Setter Property="DockPanel.Dock" Value="Right" />
     </Style>
-    
+
     <!-- Desktop mode should disable the scrim part -->
     <Style Selector="cc|SideSheet:not(:mobile) /template/ Border#PART_Scrim">
-        <Setter Property="IsEnabled" Value="False"/>
-        <Setter Property="IsVisible" Value="False"/>
+        <Setter Property="IsEnabled" Value="False" />
+        <Setter Property="IsVisible" Value="False" />
     </Style>
-    
+
     <Style Selector="cc|SideSheet:not(:mobile) /template/ Border#PART_SideSheet">
-        <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignDivider}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignDivider}" />
     </Style>
-    
+
     <Style Selector="cc|SideSheet:left:not(:mobile) /template/ Border#PART_SideSheet">
-        <Setter Property="BorderThickness" Value="0,0,1,0"/>
-        <Setter Property="DockPanel.Dock" Value="Left"/>
+        <Setter Property="BorderThickness" Value="0,0,1,0" />
+        <Setter Property="DockPanel.Dock" Value="Left" />
     </Style>
-    
+
     <Style Selector="cc|SideSheet:right:not(:mobile) /template/ Border#PART_SideSheet">
-        <Setter Property="BorderThickness" Value="1,0,0,0"/>
-        <Setter Property="DockPanel.Dock" Value="Right"/>
+        <Setter Property="BorderThickness" Value="1,0,0,0" />
+        <Setter Property="DockPanel.Dock" Value="Right" />
     </Style>
-    
+
     <Style Selector="cc|SideSheet:open /template/ Border#PART_Scrim">
         <Setter Property="Opacity" Value="0.32" />
     </Style>
-    
+
     <Design.PreviewWith>
         <Border Margin="40" BorderThickness="1" BorderBrush="Black">
             <StackPanel Orientation="Horizontal">
                 <Border>
                     <StackPanel>
-                        <TextBlock Text="Left side sheet"/>
-                        
+
                         <cc:SideSheet Width="400" Height="200"
                                       SideSheetDirection="Left"
-                                      SideSheetOpened="{Binding ElementName=LeftToggler, Path=IsChecked}">
+                                      SideSheetOpened="{Binding ElementName=LeftToggler, Path=IsChecked, Mode=TwoWay}"
+                                      SideSheetHeader="Left side sheet"
+                                      Padding="8">
                             <cc:SideSheet.SideSheetContent>
                                 <StackPanel>
                                     <Button Content="Test 1" />
                                     <Button Content="Test 2" />
                                 </StackPanel>
                             </cc:SideSheet.SideSheetContent>
-                            <cc:Card Margin="8">
+                            <cc:Card>
                                 <ToggleSwitch Name="LeftToggler" IsChecked="True" />
                             </cc:Card>
                         </cc:SideSheet>
@@ -138,18 +164,18 @@
                 </Border>
                 <Border>
                     <StackPanel>
-                        <TextBlock Text="Right side sheet"/>
-                        
                         <cc:SideSheet Width="400" Height="200"
-                                      SideSheetOpened="{Binding ElementName=toggler, Path=IsChecked}">
+                                      SideSheetOpened="{Binding ElementName=toggler, Path=IsChecked, Mode=TwoWay}"
+                                      SideSheetHeader="Right side sheet"
+                                      Padding="8">
                             <cc:SideSheet.SideSheetContent>
                                 <StackPanel>
                                     <Button Content="Test 1" />
                                     <Button Content="Test 2" />
                                 </StackPanel>
                             </cc:SideSheet.SideSheetContent>
-                            <cc:Card Margin="8">
-                                <ToggleSwitch Name="toggler" IsChecked="True" HorizontalAlignment="Right"/>
+                            <cc:Card>
+                                <ToggleSwitch Name="toggler" IsChecked="True" HorizontalAlignment="Right" />
                             </cc:Card>
                         </cc:SideSheet>
                     </StackPanel>

--- a/Material.Styles/SideSheet.xaml.cs
+++ b/Material.Styles/SideSheet.xaml.cs
@@ -29,8 +29,57 @@ namespace Material.Styles
 
         public static readonly StyledProperty<HorizontalDirection> SideSheetDirectionProperty =
             AvaloniaProperty.Register<SideSheet, HorizontalDirection>(nameof(SideSheetDirection));
+        
+        public static readonly StyledProperty<object> SideSheetHeaderProperty =
+            AvaloniaProperty.Register<SideSheet, object>(nameof(SideSheetHeader));
+        
+        public static readonly StyledProperty<IDataTemplate> SideSheetHeaderTemplateProperty =
+            AvaloniaProperty.Register<SideSheet, IDataTemplate>(nameof(SideSheetHeaderTemplate));
+        
+        public static readonly StyledProperty<Thickness> SideSheetPaddingProperty =
+            AvaloniaProperty.Register<SideSheet, Thickness>(nameof(SideSheetPadding));
+        
+        public static readonly StyledProperty<bool> SideSheetCanCloseProperty =
+            AvaloniaProperty.Register<SideSheet, bool>(nameof(SideSheetCanClose), true);
 
         // CLR properties
+        
+        /// <summary>
+        /// Hide or show the default close button
+        /// </summary>
+        public bool SideSheetCanClose
+        {
+            get => GetValue(SideSheetCanCloseProperty);
+            set => SetValue(SideSheetCanCloseProperty, value);
+        }
+        
+        /// <summary>
+        /// Gets or sets the padding in the around the <see cref="SideSheetContent"/>
+        /// </summary>
+        public Thickness SideSheetPadding
+        {
+            get { return GetValue(SideSheetPaddingProperty); }
+            set { SetValue(SideSheetPaddingProperty, value); }
+        }
+        
+        /// <summary>
+        /// Gets or sets the content of the header to display.
+        /// </summary> 
+        [DependsOn(nameof(SideSheetHeaderTemplate))]
+        public object SideSheetHeader
+        {
+            get => GetValue(SideSheetHeaderProperty);
+            set => SetValue(SideSheetHeaderProperty, value);
+        }
+        
+        /// <summary>
+        /// Gets or sets the data template used to display the header of the control.
+        /// </summary> 
+        public IDataTemplate SideSheetHeaderTemplate
+        {
+            get => GetValue(SideSheetHeaderTemplateProperty);
+            set => SetValue(SideSheetHeaderTemplateProperty, value);
+        }
         
         /// <summary>
         /// Gets or sets the content to display.
@@ -96,6 +145,11 @@ namespace Material.Styles
                 PART_Scrim = border;
                 
                 PART_Scrim.PointerPressed += PART_Scrim_Pressed;
+            }
+
+            if (e.NameScope.Find("PART_CloseButton") is Button button)
+            {
+                button.Click += (sender, args) => SideSheetOpened = false;
             }
             
             base.OnApplyTemplate(e);


### PR DESCRIPTION
Added `SideSheetHeaderProperty` and `SideSheetHeaderTemplateProperty` to define a header. Default template uses `<TextBlock Classes="Headline6"/>`. The `header` got a default `Button` bound to `SideSheetCanCloseProperty` to optional hide it. `SideSheetPaddingProperty` is used to give the `SideSheet` a seperate padding, while `Padding` is used for the content itself.

Where I am not sure right now is the connection of the `Button.Click` event to `SideSheetOpened`, see https://github.com/AvaloniaCommunity/Material.Avalonia/pull/154/commits/0d87a7e5f60d79ad2b64b47318e26e2addd60ba3#diff-f838b3d7b88edbe939d368b78bdac101af001ae766cfd8e6530208efc6dd549aR152

Also demo and preview in the template adapted.

fix #145 