### PR TITLE
Exclude non-functional DatePicker from styles collection

### DIFF
--- a/Material.Styles/MaterialToolKit.xaml
+++ b/Material.Styles/MaterialToolKit.xaml
@@ -92,7 +92,7 @@
 
   <StyleInclude Source="avares://Material.Styles/ContextMenu.xaml" />
   <!-- <StyleInclude Source="avares://Material.Styles/DataValidationErrors.xaml" /> -->
-  <StyleInclude Source="avares://Material.Styles/DatePicker.xaml" />
+  <!-- <StyleInclude Source="avares://Material.Styles/DatePicker.xaml" /> -->
   <StyleInclude Source="avares://Material.Styles/EmbeddableControlRoot.xaml" />
 
   <StyleInclude Source="avares://Material.Styles/FlyoutPresenter.axaml" />


### PR DESCRIPTION
Currently, the Material DatePicker implementation is non-functional. However, the inclusion of the Material styles into a project heavily interferes with either providing a custom style for DatePicker, or just utilizing the Avalonia.Themes.Simple. The way <themes:MaterialTheme /> is structured, it is not possible to exclude styles for particular controls, and themes:BundledTheme isn't supported anymore. As such, the style declaration for DatePicker should be removed, until a time where both DatePicker and TimePicker have consistent and functional styling Material.Avalonia.