### PR TITLE
When the default combobox style is applied, the popup doesn't close a…

### DIFF
--- a/Material.Styles/Resources/Themes/ComboBox.axaml
+++ b/Material.Styles/Resources/Themes/ComboBox.axaml
@@ -93,6 +93,7 @@
 
             <Panel Name="PART_PopupContainer">
               <Popup Name="PART_Popup"
+                     IsLightDismissEnabled="True"
                      IsOpen="{TemplateBinding IsDropDownOpen, Mode=TwoWay}">
                 <controls:Card Name="PART_Card"
                                MaxHeight="{TemplateBinding MaxDropDownHeight}"


### PR DESCRIPTION
When the default combobox style is applied, the popup doesn't close automatically if a user clicks in another area.

Issue: https://github.com/AvaloniaCommunity/Material.Avalonia/issues/313