### PR TITLE
Feature: BrushRoundConverter supports ImmutableSolidColorBrush objects

### DIFF
--- a/Material.Styles/Converters/BrushRoundConverter.cs
+++ b/Material.Styles/Converters/BrushRoundConverter.cs
@@ -16,7 +16,7 @@ namespace Material.Styles.Converters
 
         public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
         {
-            if (value is not SolidColorBrush solidColorBrush)
+            if (value is not ISolidColorBrush solidColorBrush)
                 return BindingOperations.DoNothing;
 
             var color = solidColorBrush.Color;


### PR DESCRIPTION
These are used for the named colors built into Avalonia

# Legal
I am contributing this on behalf of Garmin ©. Our legal team needs me to disclose that we are contributing this code under the [MIT license](https://github.com/AvaloniaUI/Avalonia/blob/2ab5f8b8932e0acac078a58c30ff8db908d9a9d8/licence.md) that this project used at the time of contribution.