### PR TITLE
Fix layout of snackbar (width and text alignment)

### DIFF
--- a/Material.Demo/MainWindow.axaml
+++ b/Material.Demo/MainWindow.axaml
@@ -78,6 +78,7 @@
                 <ListBoxItem>Expanders</ListBoxItem>
                 <ListBoxItem>ColorZones</ListBoxItem>
                 <ListBoxItem>Dialogs</ListBoxItem>
+                <ListBoxItem>Snackbar</ListBoxItem>
                 <ListBoxItem>ScrollViewer</ListBoxItem>
                 <ListBoxItem>SideSheet</ListBoxItem>
                 <ListBoxItem>TabControls</ListBoxItem>
@@ -189,6 +190,9 @@
 
                 <!-- Dialogs -->
                 <pages:DialogDemo />
+                
+                <!-- Snackbar -->
+                <pages:SnackbarDemo/>
 
                 <!-- ScrollViewer -->
                 <pages:ScrollViewerDemo />

--- a/Material.Demo/Material.Demo.csproj
+++ b/Material.Demo/Material.Demo.csproj
@@ -7,10 +7,10 @@
     <AvaloniaVersion>11.0.9</AvaloniaVersion>
     <IsPackable>false</IsPackable>
 
-    <PublishAot>true</PublishAot>
+<!--    <PublishAot>true</PublishAot>-->
 
-    <IsTrimmable>true</IsTrimmable>
-    <TrimMode>link</TrimMode>
+<!--    <IsTrimmable>true</IsTrimmable>-->
+<!--    <TrimMode>link</TrimMode>-->
     <!--These can help when debugging weird exceptions especially when reflection is involved. See https://github.com/dotnet/corert/blob/master/Documentation/using-corert/optimizing-corert.md -->
     <!--RootAllApplicationAssemblies: False -> TrimMode:link See https://github.com/dotnet/runtimelab/issues/597 and https://github.com/dotnet/runtimelab/blob/feature/NativeAOT/docs/using-nativeaot/optimizing.md -->
     <IlcGenerateCompleteTypeMetadata>false</IlcGenerateCompleteTypeMetadata>

--- a/Material.Demo/Material.Demo.csproj
+++ b/Material.Demo/Material.Demo.csproj
@@ -7,10 +7,10 @@
     <AvaloniaVersion>11.0.9</AvaloniaVersion>
     <IsPackable>false</IsPackable>
 
-<!--    <PublishAot>true</PublishAot>-->
+    <PublishAot>true</PublishAot>
 
-<!--    <IsTrimmable>true</IsTrimmable>-->
-<!--    <TrimMode>link</TrimMode>-->
+    <IsTrimmable>true</IsTrimmable>
+    <TrimMode>link</TrimMode>
     <!--These can help when debugging weird exceptions especially when reflection is involved. See https://github.com/dotnet/corert/blob/master/Documentation/using-corert/optimizing-corert.md -->
     <!--RootAllApplicationAssemblies: False -> TrimMode:link See https://github.com/dotnet/runtimelab/issues/597 and https://github.com/dotnet/runtimelab/blob/feature/NativeAOT/docs/using-nativeaot/optimizing.md -->
     <IlcGenerateCompleteTypeMetadata>false</IlcGenerateCompleteTypeMetadata>

--- a/Material.Demo/Pages/SnackbarDemo.axaml
+++ b/Material.Demo/Pages/SnackbarDemo.axaml
@@ -1,0 +1,39 @@
+﻿<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             xmlns:controls="clr-namespace:Material.Styles.Controls;assembly=Material.Styles"
+             xmlns:dialogHost="clr-namespace:DialogHostAvalonia;assembly=DialogHost.Avalonia"
+             xmlns:showMeTheXaml="clr-namespace:ShowMeTheXaml;assembly=ShowMeTheXaml.Avalonia"
+             x:Class="Material.Demo.Pages.SnackbarDemo">
+  <StackPanel VerticalAlignment="Top">
+    <showMeTheXaml:XamlDisplay UniqueId="Snackbar1">
+      <controls:Card Height="200">
+        <controls:SnackbarHost x:Name="SnackbarHost1" HostName="{Binding $self.Name}">
+          <StackPanel>
+            <TextBlock>Content in SnackbarHost</TextBlock>
+            <Button Click="SnackbarHost1Button_OnClick">Show Snackbar</Button>
+          </StackPanel>
+        </controls:SnackbarHost>
+      </controls:Card>
+    </showMeTheXaml:XamlDisplay>
+  <showMeTheXaml:XamlDisplay UniqueId="Snackbar2">
+    <controls:Card Height="200">
+      <dialogHost:DialogHost>
+        <controls:SnackbarHost x:Name="SnackbarHost2" HostName="{Binding $self.Name}">
+          <StackPanel>
+            <TextBlock>Content in SnackbarHost</TextBlock>
+            <TextBlock>
+              <Run>Snackbar action clicked </Run>
+              <Run x:Name="ActionCount">0</Run>
+              <Run> times</Run>
+            </TextBlock>
+            <Button Click="SnackbarHost2Button_OnClick">Show Snackbar with action</Button>
+          </StackPanel>
+        </controls:SnackbarHost>
+      </dialogHost:DialogHost>
+    </controls:Card>
+  </showMeTheXaml:XamlDisplay>
+  </StackPanel>
+</UserControl>

--- a/Material.Demo/Pages/SnackbarDemo.axaml.cs
+++ b/Material.Demo/Pages/SnackbarDemo.axaml.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using Material.Styles.Controls;
+using Material.Styles.Models;
+
+namespace Material.Demo.Pages;
+
+public partial class SnackbarDemo : UserControl {
+    private int _actionCount;
+    
+    public SnackbarDemo() {
+        InitializeComponent();
+    }
+
+    private void SnackbarHost1Button_OnClick(object? sender, RoutedEventArgs e) {
+        SnackbarHost.Post(
+            new SnackbarModel(
+                "Hello from Snackbar.",
+                TimeSpan.FromSeconds(8)),
+            SnackbarHost1.HostName,
+            DispatcherPriority.Normal);
+    }
+
+    private void SnackbarHost2Button_OnClick(object? sender, RoutedEventArgs e) {
+        SnackbarHost.Post(
+            new SnackbarModel(
+                "Hello from Snackbar.",
+                TimeSpan.FromSeconds(8),
+                new SnackbarButtonModel {
+                    Text = "Click me",
+                    Action = () => {
+                        _actionCount++;
+                        ActionCount.Text = _actionCount.ToString();
+                    }
+                }),
+            SnackbarHost2.HostName,
+            DispatcherPriority.Normal);
+    }
+}

--- a/Material.Styles/Controls/SnackbarHost.axaml
+++ b/Material.Styles/Controls/SnackbarHost.axaml
@@ -30,7 +30,7 @@
             </ItemsControl.ItemsPanel>
             <ItemsControl.ItemTemplate>
               <DataTemplate DataType="models:SnackbarModel">
-                <controls:Card Padding="0" Margin="8" Width="344">
+                <controls:Card Padding="0" Margin="8" MinWidth="344">
                   <Grid ColumnDefinitions="16,*,8,Auto,8" RowDefinitions="6,Auto,6" Margin="0, 8">
                     <ContentPresenter Grid.Column="1" Grid.Row="1"
                                       Content="{Binding Content,
@@ -38,6 +38,7 @@
                       <ContentPresenter.DataTemplates>
                         <DataTemplate DataType="system:String">
                           <TextBlock Name="PART_SnackbarSupportingText"
+                                     VerticalAlignment="Center"
                                      Text="{Binding}"
                                      Theme="{StaticResource MaterialSnackbarHostSupportingTextBlock}" />
                         </DataTemplate>


### PR DESCRIPTION
Fixes the width of snachkbar from the fixed value fo 344 to an minimum width.
also fixe the vertical text alignment which looked wrong if e.g. a button is shown (top aligned vs center).

Also adds a demo page for snackbarhost

fixes #352