### PR TITLE
Fix for LeftHeader class for ToggleSwich

### DIFF
--- a/Material.Styles/Resources/Themes/ToggleSwitch.axaml
+++ b/Material.Styles/Resources/Themes/ToggleSwitch.axaml
@@ -149,6 +149,12 @@
                     Path=(assists:ToggleSwitchAssist.SwitchTrackOnBackground)}" />
     </Style>
 
+    <!-- Left-right handle variant -->
+
+    <Style Selector="^.LeftHeader /template/ DockPanel#PART_RootPanel > Viewbox">
+				<Setter Property="DockPanel.Dock" Value="Right" />
+    </Style>
+
     <!-- Accent variant -->
 
     <Style Selector="^.accent">


### PR DESCRIPTION
I added handler for LeftHeader class for ToggleSwitch to comply with demo project.
For some reason it wasn't there, i added this style and checked in my project, it worked as expected