### PR TITLE
Fix for the progress bar corner radius issue #372

### DIFF
--- a/Material.Styles/Resources/Themes/ProgressBar.axaml
+++ b/Material.Styles/Resources/Themes/ProgressBar.axaml
@@ -53,7 +53,8 @@
                 Background="{TemplateBinding Background}"
                 BorderBrush="{TemplateBinding BorderBrush}"
                 BorderThickness="{TemplateBinding BorderThickness}"
-                CornerRadius="{TemplateBinding CornerRadius}">
+                CornerRadius="{TemplateBinding CornerRadius}"
+                ClipToBounds="True">
           <Panel Name="PART_RootPanel">
             <Rectangle Name="PART_IndeterminateFirst"
                        IsVisible="{TemplateBinding IsIndeterminate}"


### PR DESCRIPTION
Fixed a bug causing the corner radius that are set to a ProgressBar, not being applied to the top left and the bottom left corners.