### PR TITLE
Prevent the Numerge.MSBuild leaking as the dependency

### DIFF
--- a/Material.Avalonia/Material.Avalonia.csproj
+++ b/Material.Avalonia/Material.Avalonia.csproj
@@ -19,6 +19,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Numerge.MSBuild"/>
+    <PackageReference Include="Numerge.MSBuild">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Prevent the Numerge.MSBuild leaking as the dependency to Material.Avalonia