### PR TITLE
Fix ToggleButton Background Not Bound

### DIFF
--- a/Material.Styles/Resources/Themes/ToggleButton.axaml
+++ b/Material.Styles/Resources/Themes/ToggleButton.axaml
@@ -68,6 +68,7 @@
     <Setter Property="Template">
       <ControlTemplate>
         <Border Name="PART_RootBorder"
+                Background="{TemplateBinding Background}"
                 BorderBrush="{TemplateBinding BorderBrush}"
                 BorderThickness="{TemplateBinding BorderThickness}"
                 CornerRadius="{TemplateBinding CornerRadius}"


### PR DESCRIPTION
It just brings back the missing
```
Background="{TemplateBinding Background}"
```
on
```xml
<Border Name="PART_RootBorder"
```
for ToggleButton