### PR TITLE
Make .icon buttons background transparent

### DIFF
--- a/Material.Styles/Controls/SideSheet.axaml
+++ b/Material.Styles/Controls/SideSheet.axaml
@@ -79,7 +79,8 @@
                     Padding="{TemplateBinding SideSheetPadding}">
               <StackPanel Name="PART_SideSheetPanel">
                 <DockPanel Name="PART_HeaderPanel">
-                  <Button Name="PART_CloseButton" DockPanel.Dock="Right" Classes="icon"
+                  <Button Name="PART_CloseButton" DockPanel.Dock="Right" 
+                          Theme="{StaticResource MaterialIconButton}"
                           IsVisible="{TemplateBinding SideSheetCanClose}">
                     <controls:MaterialInternalIcon Name="PART_Icon" Kind="Close" />
                   </Button>

--- a/Material.Styles/Resources/Themes/Button.axaml
+++ b/Material.Styles/Resources/Themes/Button.axaml
@@ -117,6 +117,9 @@
     </Style>
     
     <Style Selector="^.icon">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="assists:ShadowAssist.ShadowDepth" Value="Depth0" />
+      
       <Setter Property="Padding" Value="12" />
       <Setter Property="CornerRadius" Value="24" />
       <Setter Property="Height" Value="48" />


### PR DESCRIPTION
- Make .icon buttons background transparent
- Replace Theme for MaterialIconButton in SideSheet closing button

Fixes #397 