### PR TITLE
fix 417 - NotificationCard Background

### DIFF
--- a/Material.Styles/Resources/Themes/NotificationCard.axaml
+++ b/Material.Styles/Resources/Themes/NotificationCard.axaml
@@ -11,6 +11,7 @@
     <Setter Property="Width" Value="350" />
     <Setter Property="FontSize" Value="14" />
     <Setter Property="RenderTransformOrigin" Value="50%,75%" />
+    <Setter Property="Background" Value="{DynamicResource MaterialPrimaryMidBrush}" />
     <Setter Property="Template">
       <ControlTemplate>
         <LayoutTransformControl Name="PART_LayoutTransformControl" UseRenderTransform="True">

--- a/Material.Styles/Resources/Themes/NotificationCard.axaml
+++ b/Material.Styles/Resources/Themes/NotificationCard.axaml
@@ -73,6 +73,26 @@
         </KeyFrame>
       </Animation>
     </ControlTheme.Animations>
+
+    <!--  Colour variants  -->
+    <Style Selector="^.light">
+      <Setter Property="Background" Value="{DynamicResource MaterialPrimaryLightBrush}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource MaterialPrimaryLightBrush}" />
+      <Setter Property="Foreground" Value="{DynamicResource MaterialPrimaryLightForegroundBrush}" />
+    </Style>
+
+    <Style Selector="^.dark">
+      <Setter Property="Background" Value="{DynamicResource MaterialPrimaryDarkBrush}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource MaterialPrimaryDarkBrush}" />
+      <Setter Property="Foreground" Value="{DynamicResource MaterialPrimaryForegroundBrush}" />
+    </Style>
+
+    <Style Selector="^.accent">
+      <Setter Property="Background" Value="{DynamicResource MaterialSecondaryMidBrush}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource MaterialSecondaryMidBrush}" />
+      <Setter Property="Foreground" Value="{DynamicResource MaterialSecondaryMidForegroundBrush}" />
+    </Style>
+
   </ControlTheme>
 
   <ControlTheme x:Key="{x:Type NotificationCard}" TargetType="NotificationCard"


### PR DESCRIPTION
added the light, dark and accent style classes (I think they are called?) to the `NotificationCard`s ControlTheme so the `Background` can be controlled like the following:
```csharp
var topLevel = TopLevel.GetTopLevel(this);
WindowNotificationManager? _manager = new WindowNotificationManager(topLevel);
_manager.Show("Notification with \"light\" class", NotificationType.Error, classes: ["light"]);
_manager.Show("Notification with \"dark\" class", NotificationType.Error, classes: ["dark"]);
_manager.Show("Notification with \"accent\" class", NotificationType.Error, classes: ["accent"]);
```
Result:
![image](https://github.com/user-attachments/assets/3a326264-9ede-427a-acbb-80ce6f342c8e)

this should fix #417, at least I think this is the correct change for the API