### PR TITLE
Centered place holder text in combobox

### DIFF
--- a/Material.Styles/Resources/Themes/ComboBox.axaml
+++ b/Material.Styles/Resources/Themes/ComboBox.axaml
@@ -59,6 +59,7 @@
                   <Panel Name="PART_InnerPanel" HorizontalAlignment="Left">
                     <TextBlock Name="PART_PlaceholderText"
                                Text="{TemplateBinding PlaceholderText}"
+                               VerticalAlignment="Center"
                                Foreground="{TemplateBinding PlaceholderForeground}" />
 
                     <ContentPresenter Name="PART_ContentPresenter"


### PR DESCRIPTION
I think centering the place holder text in the default combobox style makes more sense?

## Old behavior
![image](https://github.com/user-attachments/assets/c43fce1a-0849-4321-b48d-2274f702b1b7)

## New bebavior
![image](https://github.com/user-attachments/assets/5e3dfd46-a948-4302-82d1-1cd5584db2ae)
