### PR TITLE
Add fields line up demo

### DIFF
--- a/Material.Avalonia.Demo/MainView.axaml
+++ b/Material.Avalonia.Demo/MainView.axaml
@@ -72,6 +72,7 @@
                 <ListBoxItem>Dialogs</ListBoxItem>
                 <ListBoxItem>Expanders</ListBoxItem>
                 <ListBoxItem>Fields</ListBoxItem>
+                <ListBoxItem>Fields line up</ListBoxItem>
                 <ListBoxItem>Lists</ListBoxItem>
                 <ListBoxItem>Material Icons</ListBoxItem>
                 <ListBoxItem>Progress indicators</ListBoxItem>
@@ -179,6 +180,9 @@
                 
                 <!-- Fields -->
                 <pages:FieldsDemo />
+
+                <!-- FieldsLline up -->
+                <pages:FieldsLineUpDemo />
                 
                 <!-- Lists -->
                 <pages:ListsDemo />

--- a/Material.Avalonia.Demo/Material.Avalonia.Demo.csproj
+++ b/Material.Avalonia.Demo/Material.Avalonia.Demo.csproj
@@ -6,23 +6,23 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia.Controls.DataGrid"/>
-    <PackageReference Include="Avalonia.Diagnostics"/>
-    <PackageReference Include="Avalonia.Themes.Simple"/>
-    <PackageReference Include="Material.Icons.Avalonia"/>
-    <PackageReference Include="DialogHost.Avalonia"/>
-    <PackageReference Include="ShowMeTheXaml.Avalonia"/>
-    <PackageReference Include="ShowMeTheXaml.Avalonia.AvaloniaEdit"/>
-    <PackageReference Include="ShowMeTheXaml.Avalonia.Generator" PrivateAssets="all"/>
+    <PackageReference Include="Avalonia.Controls.DataGrid" />
+    <PackageReference Include="Avalonia.Diagnostics" />
+    <PackageReference Include="Avalonia.Themes.Simple" />
+    <PackageReference Include="Material.Icons.Avalonia" />
+    <PackageReference Include="DialogHost.Avalonia" />
+    <PackageReference Include="ShowMeTheXaml.Avalonia" />
+    <PackageReference Include="ShowMeTheXaml.Avalonia.AvaloniaEdit" />
+    <PackageReference Include="ShowMeTheXaml.Avalonia.Generator" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Material.Avalonia\Material.Avalonia.csproj"/>
+    <ProjectReference Include="..\Material.Avalonia\Material.Avalonia.csproj" />
     <ProjectReference Include="..\Material.Avalonia.Dialogs\Material.Avalonia.Dialogs.csproj" />
     <ProjectReference Include="..\Material.Avalonia.DataGrid\Material.Avalonia.DataGrid.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <AvaloniaResource Include="Assets\**"/>
+    <AvaloniaResource Include="Assets\**" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Material.Avalonia.Demo/Pages/FieldsLineUpDemo.axaml
+++ b/Material.Avalonia.Demo/Pages/FieldsLineUpDemo.axaml
@@ -113,14 +113,12 @@
      <TextBox Grid.Row="3"
               Grid.Column="1"
               Theme="{StaticResource FilledTextBox}"
-              wpf:TextFieldAssist.Label="{Binding AssistLabel}" 
               />
      <TextBox Grid.Row="4"
               Grid.Column="1"
               Theme="{StaticResource OutlineTextBox}"
               UseFloatingWatermark="True"
               Classes="outline"
-              wpf:TextFieldAssist.Label="{Binding AssistLabel}" 
               />
 
      <TextBox Classes="revealPasswordButton"
@@ -136,10 +134,11 @@
               Grid.Row="3"
               Grid.Column="2"
               Theme="{StaticResource FilledTextBox}" />
-     <TextBox Classes="revealPasswordButton"
+     <TextBox Classes="revealPasswordButton outline"
               Grid.Row="4"
               Grid.Column="2"
-              Theme="{StaticResource OutlineTextBox}" />
+              Theme="{StaticResource OutlineTextBox}"
+              UseFloatingWatermark="True" />
 
      <ComboBox Grid.Row="1"
                Grid.Column="3" />

--- a/Material.Avalonia.Demo/Pages/FieldsLineUpDemo.axaml
+++ b/Material.Avalonia.Demo/Pages/FieldsLineUpDemo.axaml
@@ -1,0 +1,216 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:controls="clr-namespace:Material.Styles.Controls;assembly=Material.Styles"
+             xmlns:wpf="clr-namespace:Material.Styles.Assists;assembly=Material.Styles"
+             xmlns:showMeTheXaml="clr-namespace:ShowMeTheXaml;assembly=ShowMeTheXaml.Avalonia"
+             xmlns:viewModels="clr-namespace:Material.Avalonia.Demo.ViewModels"
+             x:DataType="viewModels:FieldsLineUpDemoViewModel"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="Material.Avalonia.Demo.Pages.FieldsLineUpDemo" Padding="32">
+  <UserControl.DataContext>
+    <viewModels:FieldsLineUpDemoViewModel/>
+  </UserControl.DataContext>
+  <StackPanel>
+    <Grid RowDefinitions="auto, *">
+      <Grid.Styles>
+        <Style Selector="TextBox">
+          <Setter Property="Theme" Value="{StaticResource FilledTextBox}" />
+          <Setter Property="Margin" Value="2" />
+        </Style>
+      </Grid.Styles>
+      <controls:ColorZone Mode="PrimaryMid">
+          <TextBlock Classes="Headline6" Text="Options"/>
+      </controls:ColorZone>
+
+      <WrapPanel Grid.Row="1">
+        <StackPanel>
+          <TextBox wpf:TextFieldAssist.Label="wpf:TextFieldAssist.Label"
+                   Text="{Binding AssistLabel}"
+                   Margin="0 2" />
+          <TextBox wpf:TextFieldAssist.Label="Watermark"
+                   Text="{Binding Watermark}"
+                   Margin="0 2" />
+        </StackPanel>
+      </WrapPanel>
+      
+    </Grid>
+    <Grid x:Name="FieldsLineUpGrid" HorizontalAlignment="Center" VerticalAlignment="Center">
+      <Grid.Styles>
+        <!--TextBlocks-->
+        <Style Selector="TextBlock">
+          <Setter Property="HorizontalAlignment" Value="Center" />
+          <Setter Property="VerticalAlignment" Value="Center" />
+        </Style>
+        <!--TextBoxes-->
+        <Style Selector="TextBox">
+          <Setter Property="Text" Value="Text" />
+          <Setter Property="wpf:TextFieldAssist.Label"  Value="{Binding AssistLabel}" />
+          <Setter Property="Watermark"  Value="{Binding Watermark}" />
+        </Style>
+        <!--ComboBoxes-->
+        <Style Selector="ComboBox">
+          <Setter Property="ItemsSource" Value="{Binding ComboBoxItems}" />
+        </Style>
+      </Grid.Styles>
+      <Grid.RowDefinitions>
+       <RowDefinition Height="Auto" />
+       <RowDefinition Height="Auto" />
+       <RowDefinition Height="Auto" />
+       <RowDefinition Height="Auto" />
+       <RowDefinition Height="Auto" />
+     </Grid.RowDefinitions>
+     <Grid.ColumnDefinitions>
+       <ColumnDefinition Width="Auto" />
+       <ColumnDefinition MinWidth="100" />
+       <ColumnDefinition MinWidth="100" />
+       <ColumnDefinition MinWidth="100" />
+       <ColumnDefinition MinWidth="100" />
+       <ColumnDefinition MinWidth="100" />
+       <ColumnDefinition MinWidth="100" />
+       <ColumnDefinition MinWidth="100" />
+     </Grid.ColumnDefinitions>
+    
+     <TextBlock Grid.Row="1"
+                Grid.Column="0"
+                Text="Default" />
+     <TextBlock Grid.Row="2"
+                Grid.Column="0"
+                Text="Floating" />
+     <TextBlock Grid.Row="3"
+                Grid.Column="0"
+                Text="Filled" />
+     <TextBlock Grid.Row="4"
+                Grid.Column="0"
+                Text="Outlined" />
+
+     <TextBlock Grid.Row="0"
+                Grid.Column="1"
+                Text="TextField" />
+     <TextBlock Grid.Row="0"
+                Grid.Column="2"
+                Text="PasswordBox" />
+     <TextBlock Grid.Row="0"
+                Grid.Column="3"
+                Text="ComboBox" />
+     <TextBlock Grid.Row="0"
+                Grid.Column="4"
+                Text="DatePicker" />
+     <TextBlock Grid.Row="0"
+                Grid.Column="5"
+                Text="TimePicker" />
+     <TextBlock Grid.Row="0"
+                Grid.Column="6"
+                Text="NumericUpDown" />
+     <TextBlock Grid.Row="0"
+                Grid.Column="7"
+                Text="AutoSuggestBox " />
+
+     <TextBox Grid.Row="1" 
+              Grid.Column="1" 
+              wpf:TextFieldAssist.Label="{x:Null}"
+              />
+     <TextBox Grid.Row="2"
+              Grid.Column="1"
+              UseFloatingWatermark="True" />
+     <TextBox Grid.Row="3"
+              Grid.Column="1"
+              Theme="{StaticResource FilledTextBox}"
+              wpf:TextFieldAssist.Label="{Binding AssistLabel}" 
+              />
+     <TextBox Grid.Row="4"
+              Grid.Column="1"
+              Theme="{StaticResource OutlineTextBox}"
+              UseFloatingWatermark="True"
+              Classes="outline"
+              wpf:TextFieldAssist.Label="{Binding AssistLabel}" 
+              />
+
+     <TextBox Classes="revealPasswordButton"
+              Grid.Row="1"
+              Grid.Column="2"
+               />
+     <TextBox Classes="revealPasswordButton"
+              Grid.Row="2"
+              Grid.Column="2"
+              UseFloatingWatermark="True"/>
+     <TextBox Classes="revealPasswordButton"
+              Grid.Row="3"
+              Grid.Column="2"
+              Theme="{StaticResource FilledTextBox}" />
+     <TextBox Classes="revealPasswordButton"
+              Grid.Row="4"
+              Grid.Column="2"
+              Theme="{StaticResource OutlineTextBox}" />
+
+     <ComboBox Grid.Row="1"
+               Grid.Column="3" />
+     <ComboBox Grid.Row="2"
+               Grid.Column="3"
+               wpf:ComboBoxAssist.Label="{Binding AssistLabel}" />
+     <ComboBox Grid.Row="3"
+               Grid.Column="3"
+               wpf:ComboBoxAssist.Label="{Binding AssistLabel}"
+               Theme="{StaticResource MaterialFilledComboBox}" />
+     <ComboBox Grid.Row="4"
+               Grid.Column="3"
+               wpf:ComboBoxAssist.Label="{Binding AssistLabel}"
+               Theme="{StaticResource MaterialOutlineComboBox}" />
+
+     <DatePicker Grid.Row="1"
+                 Grid.Column="4" />
+     <DatePicker Grid.Row="2" 
+                 Grid.Column="4"
+                 wpf:TextFieldAssist.Label="{Binding AssistLabel}" />
+     <DatePicker Grid.Row="3"
+                 Grid.Column="4"
+                 wpf:TextFieldAssist.Label="{Binding AssistLabel}" />
+     <DatePicker Grid.Row="4"
+                 Grid.Column="4"
+                 wpf:TextFieldAssist.Label="{Binding AssistLabel}" />
+
+     <TimePicker Grid.Row="1"
+                 Grid.Column="5" />
+     <TimePicker Grid.Row="2"
+                 Grid.Column="5" />
+     <TimePicker Grid.Row="3"
+                 Grid.Column="5" />
+     <TimePicker Grid.Row="4"
+                 Grid.Column="5" />
+
+      <!--<NumericUpDown Watermark="Enter text"
+                         p1:TextFieldAssist.Hints="Here is the hint"
+                         p1:TextFieldAssist.Label="Cool label"
+                         xmlns:p1="clr-namespace:Material.Styles.Assists;assembly=Material.Styles" />-->
+
+      
+     <NumericUpDown Grid.Row="1"
+                    Grid.Column="6"
+                    wpf:TextFieldAssist.Label="{Binding AssistLabel}" />
+     <NumericUpDown Grid.Row="2"
+                    Grid.Column="6"
+                    wpf:TextFieldAssist.Label="{Binding AssistLabel}" />
+     <NumericUpDown Grid.Row="3"
+                    Grid.Column="6"
+                    wpf:TextFieldAssist.Label="{Binding AssistLabel}"
+                    Theme="{StaticResource FilledNumericUpDown}" />
+     <NumericUpDown Grid.Row="4"
+                    Grid.Column="6"
+                    wpf:TextFieldAssist.Label="{Binding AssistLabel}"
+                    Theme="{StaticResource OutlineNumericUpDown}" />
+
+     <!--<materialDesign:AutoSuggestBox Grid.Row="1" Grid.Column="7" />
+     <materialDesign:AutoSuggestBox Grid.Row="2"
+                                    Grid.Column="7"
+                                    Style="{StaticResource MaterialDesignFloatingHintAutoSuggestBox}" />
+     <materialDesign:AutoSuggestBox Grid.Row="3"
+                                    Grid.Column="7"
+                                    Style="{StaticResource MaterialDesignFilledAutoSuggestBox}" />
+     <materialDesign:AutoSuggestBox Grid.Row="4"
+                                    Grid.Column="7"
+                                    Style="{StaticResource MaterialDesignOutlinedAutoSuggestBox}" />-->
+
+    </Grid>
+  </StackPanel>
+</UserControl>

--- a/Material.Avalonia.Demo/Pages/FieldsLineUpDemo.axaml
+++ b/Material.Avalonia.Demo/Pages/FieldsLineUpDemo.axaml
@@ -69,7 +69,6 @@
        <ColumnDefinition MinWidth="100" />
        <ColumnDefinition MinWidth="100" />
        <ColumnDefinition MinWidth="100" />
-       <ColumnDefinition MinWidth="100" />
      </Grid.ColumnDefinitions>
     
      <TextBlock Grid.Row="1"
@@ -103,9 +102,6 @@
      <TextBlock Grid.Row="0"
                 Grid.Column="6"
                 Text="NumericUpDown" />
-     <TextBlock Grid.Row="0"
-                Grid.Column="7"
-                Text="AutoSuggestBox " />
 
      <TextBox Grid.Row="1" 
               Grid.Column="1" 
@@ -130,6 +126,7 @@
      <TextBox Classes="revealPasswordButton"
               Grid.Row="1"
               Grid.Column="2"
+              wpf:TextFieldAssist.Label="{x:Null}"
                />
      <TextBox Classes="revealPasswordButton"
               Grid.Row="2"
@@ -178,12 +175,6 @@
                  Grid.Column="5" />
      <TimePicker Grid.Row="4"
                  Grid.Column="5" />
-
-      <!--<NumericUpDown Watermark="Enter text"
-                         p1:TextFieldAssist.Hints="Here is the hint"
-                         p1:TextFieldAssist.Label="Cool label"
-                         xmlns:p1="clr-namespace:Material.Styles.Assists;assembly=Material.Styles" />-->
-
       
      <NumericUpDown Grid.Row="1"
                     Grid.Column="6"
@@ -199,17 +190,6 @@
                     Grid.Column="6"
                     wpf:TextFieldAssist.Label="{Binding AssistLabel}"
                     Theme="{StaticResource OutlineNumericUpDown}" />
-
-     <!--<materialDesign:AutoSuggestBox Grid.Row="1" Grid.Column="7" />
-     <materialDesign:AutoSuggestBox Grid.Row="2"
-                                    Grid.Column="7"
-                                    Style="{StaticResource MaterialDesignFloatingHintAutoSuggestBox}" />
-     <materialDesign:AutoSuggestBox Grid.Row="3"
-                                    Grid.Column="7"
-                                    Style="{StaticResource MaterialDesignFilledAutoSuggestBox}" />
-     <materialDesign:AutoSuggestBox Grid.Row="4"
-                                    Grid.Column="7"
-                                    Style="{StaticResource MaterialDesignOutlinedAutoSuggestBox}" />-->
 
     </Grid>
   </StackPanel>

--- a/Material.Avalonia.Demo/Pages/FieldsLineUpDemo.axaml.cs
+++ b/Material.Avalonia.Demo/Pages/FieldsLineUpDemo.axaml.cs
@@ -1,0 +1,13 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Markup.Xaml;
+using Material.Avalonia.Demo.ViewModels;
+
+namespace Material.Avalonia.Demo.Pages;
+
+public partial class FieldsLineUpDemo : UserControl {
+    public FieldsLineUpDemo() {
+        InitializeComponent();
+    }
+}

--- a/Material.Avalonia.Demo/ViewModels/FieldsLineUpDemoViewModel.cs
+++ b/Material.Avalonia.Demo/ViewModels/FieldsLineUpDemoViewModel.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Material.Avalonia.Demo.ViewModels;
+internal class FieldsLineUpDemoViewModel : ViewModelBase {
+    private string? _assistLabel = "My assist label";
+    public string? AssistLabel {
+        get => _assistLabel;
+        set {
+            if (_assistLabel != value) {
+                _assistLabel = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    private string? _watermark = "My watermark";
+    public string? Watermark {
+        get => _watermark;
+        set {
+            if (_watermark != value) {
+                _watermark = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+
+
+    public IList<string> ComboBoxItems { get; } = [
+        "Item 1",
+        "Item 2",
+        "Item 3",
+        "Item 4",
+        "Item 5"
+    ];
+}


### PR DESCRIPTION
I added a "Fields line up" to the demo app, like we have in [MDIX](https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit).

I think this gives quite a nice overview of all the controls :smile: