### PR TITLE
hide watermark when the FilledTextBox is not focused

### DIFF
--- a/Material.Avalonia.Demo/Pages/FieldsLineUpDemo.axaml
+++ b/Material.Avalonia.Demo/Pages/FieldsLineUpDemo.axaml
@@ -122,19 +122,22 @@
               />
 
      <TextBox Classes="revealPasswordButton"
+              PasswordChar="*"
               Grid.Row="1"
               Grid.Column="2"
-              wpf:TextFieldAssist.Label="{x:Null}"
-               />
+              wpf:TextFieldAssist.Label="{x:Null}" />
      <TextBox Classes="revealPasswordButton"
+              PasswordChar="*"
               Grid.Row="2"
               Grid.Column="2"
-              UseFloatingWatermark="True"/>
+              UseFloatingWatermark="True" />
      <TextBox Classes="revealPasswordButton"
+              PasswordChar="*"
               Grid.Row="3"
               Grid.Column="2"
               Theme="{StaticResource FilledTextBox}" />
      <TextBox Classes="revealPasswordButton outline"
+              PasswordChar="*"
               Grid.Row="4"
               Grid.Column="2"
               Theme="{StaticResource OutlineTextBox}"

--- a/Material.Styles/Resources/Themes/TextBox.axaml
+++ b/Material.Styles/Resources/Themes/TextBox.axaml
@@ -472,6 +472,9 @@
     </Style>
 
     <!-- Feedbacks -->
+    <Style Selector="^:not(:focus-within) /template/ TextBlock#PART_PlaceholderText">
+      <Setter Property="IsVisible" Value="False"/>
+    </Style>
 
     <Style Selector="^:empty:not(:focus-within) /template/ Border#PART_LabelRootBorder">
       <Setter Property="Margin" Value="12,18,1,1" />


### PR DESCRIPTION
fixes an issue where the `Watermark` overlaps the `TextFieldAssist.Label` if the `FilledTextBox` style is used, the TextBox is not focused and the TextBox is empty.

Additionally the "PasswordBoxes" in the new demo page now show the `PasswordChar="*"`

## Old behavior
![image](https://github.com/user-attachments/assets/6c2f3dde-be9f-449c-b3aa-44636a4028ea)

## New bebavior
![image](https://github.com/user-attachments/assets/ebdd358b-b6d5-4709-9a98-1c9fb2681c79)
