### PR TITLE
Add HyperlinkButton theming support

### DIFF
--- a/Material.Avalonia.Demo/Pages/ButtonsDemo.axaml
+++ b/Material.Avalonia.Demo/Pages/ButtonsDemo.axaml
@@ -6,7 +6,9 @@
              xmlns:avalonia="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
              xmlns:controls="clr-namespace:Material.Styles.Controls;assembly=Material.Styles"
              xmlns:showMeTheXaml="clr-namespace:ShowMeTheXaml;assembly=ShowMeTheXaml.Avalonia"
-             x:Class="Material.Avalonia.Demo.Pages.ButtonsDemo">
+             xmlns:assists="clr-namespace:Material.Styles.Assists;assembly=Material.Styles"
+             x:Class="Material.Avalonia.Demo.Pages.ButtonsDemo"
+             Name="ButtonsDemoPageControl">
   <StackPanel Margin="16, 0">
     <StackPanel.Styles>
       <Style Selector="Button">
@@ -190,5 +192,45 @@
       </showMeTheXaml:XamlDisplay>
     </StackPanel>
 
+    <TextBlock Classes="Headline6 Subheadline2" Text="Hyperlink buttons" />
+    <StackPanel Orientation="Horizontal">
+      <StackPanel.Styles>
+        <Style Selector="showMeTheXaml|XamlDisplay">
+          <Setter Property="Margin" Value="8" />
+        </Style>
+      </StackPanel.Styles>
+      <showMeTheXaml:XamlDisplay UniqueId="HyperlinkButtons0">
+        <HyperlinkButton Theme="{StaticResource MaterialHyperlinkButton}"
+                         Content="A hyperlink!"
+                         ToolTip.Tip='A simple hyperlink!' 
+                         Command="{Binding #ButtonsDemoPageControl.OnHyperlink1Clicked}"/>
+      </showMeTheXaml:XamlDisplay>
+      
+      <showMeTheXaml:XamlDisplay UniqueId="HyperlinkButtons1">
+        <HyperlinkButton IsVisited="False"
+                         Theme="{StaticResource MaterialHyperlinkButton}"
+                         Content="Another hyperlink!"
+                         ToolTip.Tip='Another hyperlink!'
+                         Command="{Binding #ButtonsDemoPageControl.OnHyperlink2Clicked}"/>
+      </showMeTheXaml:XamlDisplay>
+      
+      <!-- add assists:ButtonAssist.IsClicked="{x:Null}" to ignore memorise visited feature -->
+      <showMeTheXaml:XamlDisplay UniqueId="HyperlinkButtons2">
+        <HyperlinkButton assists:ButtonAssist.IsClicked="{x:Null}"
+                         Theme="{StaticResource MaterialHyperlinkButton}"
+                         Content="Another hyperlink, but not to memorise visited!"
+                         ToolTip.Tip='I dont remember visited or not lol'
+                         Command="{Binding #ButtonsDemoPageControl.OnHyperlink2Clicked}"/>
+      </showMeTheXaml:XamlDisplay>
+      
+      <showMeTheXaml:XamlDisplay UniqueId="HyperlinkButtons3">
+        <HyperlinkButton IsVisited="False"
+                         IsEnabled="False"
+                         Theme="{StaticResource MaterialHyperlinkButton}"
+                         Content="a disabled hyperlink"
+                         ToolTip.Tip='not clickable hyperlink'
+                         Command="{Binding #ButtonsDemoPageControl.OnHyperlink2Clicked}"/>
+      </showMeTheXaml:XamlDisplay>
+    </StackPanel>
   </StackPanel>
 </UserControl>

--- a/Material.Avalonia.Demo/Pages/ButtonsDemo.axaml.cs
+++ b/Material.Avalonia.Demo/Pages/ButtonsDemo.axaml.cs
@@ -1,9 +1,18 @@
-﻿using Avalonia.Controls;
+﻿using System;
+using Avalonia.Controls;
 
 namespace Material.Avalonia.Demo.Pages;
 
 public partial class ButtonsDemo : UserControl {
     public ButtonsDemo() {
         InitializeComponent();
+    }
+
+    public void OnHyperlink1Clicked() {
+        Console.WriteLine("Hyperlink #1 CLICKED!");
+    }
+    
+    public void OnHyperlink2Clicked() {
+        Console.WriteLine("Another Hyperlink is CLICKED!");
     }
 }

--- a/Material.Styles/Assists/ButtonAssist.cs
+++ b/Material.Styles/Assists/ButtonAssist.cs
@@ -1,6 +1,8 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Interactivity;
 using Avalonia.Media;
+using Material.Styles.Internal;
 
 namespace Material.Styles.Assists
 {
@@ -29,6 +31,49 @@ namespace Material.Styles.Assists
 
         public static IBrush? GetClickFeedbackColor(AvaloniaObject element) =>
             element.GetValue<IBrush?>(ClickFeedbackColorProperty);
+
+        #endregion
+        
+        // Used for memorise which hyperlink button clicked (or just say, visited)
+        #region AttachedProperty : IsClicked
+
+        public static readonly AvaloniaProperty<bool?> IsClickedProperty =
+            AvaloniaProperty.RegisterAttached<Button, bool?>("IsClicked", typeof(ButtonAssist));
+
+        public static void SetIsClicked(AvaloniaObject element, bool? value) =>
+            element.SetValue(IsClickedProperty, value);
+
+        public static bool? GetIsClicked(AvaloniaObject element) =>
+            element.GetValue<bool?>(IsClickedProperty);
+
+        
+        private static void OnButtonClickedPrivate((object, RoutedEventArgs) args) {
+            if(args.Item1 is not Button button)
+                return;
+
+            var value = button.GetValue<bool?>(IsClickedProperty);
+            
+            // null means not required for handling
+            if(!value.HasValue)
+                return;
+
+            // if IsClickedProperty is false, put it to true
+            if (!value.Value)
+                button.SetValue(IsClickedProperty, true);
+            
+            if (button is not HyperlinkButton hyperlink)
+                return;
+
+            hyperlink.IsVisited = true;
+        }
+
+        #endregion
+
+        #region Initiator (used for observe control changes)
+
+        static ButtonAssist() {
+            Button.ClickEvent.Raised.Subscribe(OnButtonClickedPrivate);
+        }
 
         #endregion
     }

--- a/Material.Styles/Assists/ButtonAssist.cs
+++ b/Material.Styles/Assists/ButtonAssist.cs
@@ -1,8 +1,6 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Interactivity;
 using Avalonia.Media;
-using Material.Styles.Internal;
 
 namespace Material.Styles.Assists
 {
@@ -31,49 +29,6 @@ namespace Material.Styles.Assists
 
         public static IBrush? GetClickFeedbackColor(AvaloniaObject element) =>
             element.GetValue<IBrush?>(ClickFeedbackColorProperty);
-
-        #endregion
-        
-        // Used for memorise which hyperlink button clicked (or just say, visited)
-        #region AttachedProperty : IsClicked
-
-        public static readonly AvaloniaProperty<bool?> IsClickedProperty =
-            AvaloniaProperty.RegisterAttached<Button, bool?>("IsClicked", typeof(ButtonAssist));
-
-        public static void SetIsClicked(AvaloniaObject element, bool? value) =>
-            element.SetValue(IsClickedProperty, value);
-
-        public static bool? GetIsClicked(AvaloniaObject element) =>
-            element.GetValue<bool?>(IsClickedProperty);
-
-        
-        private static void OnButtonClickedPrivate((object, RoutedEventArgs) args) {
-            if(args.Item1 is not Button button)
-                return;
-
-            var value = button.GetValue<bool?>(IsClickedProperty);
-            
-            // null means not required for handling
-            if(!value.HasValue)
-                return;
-
-            // if IsClickedProperty is false, put it to true
-            if (!value.Value)
-                button.SetValue(IsClickedProperty, true);
-            
-            if (button is not HyperlinkButton hyperlink)
-                return;
-
-            hyperlink.IsVisited = true;
-        }
-
-        #endregion
-
-        #region Initiator (used for observe control changes)
-
-        static ButtonAssist() {
-            Button.ClickEvent.Raised.Subscribe(OnButtonClickedPrivate);
-        }
 
         #endregion
     }

--- a/Material.Styles/MaterialToolKit.xaml
+++ b/Material.Styles/MaterialToolKit.xaml
@@ -48,6 +48,7 @@
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/FlyoutPresenter.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/FontFamily.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/GridSplitter.axaml" />
+        <ResourceInclude Source="avares://Material.Styles/Resources/Themes/HyperlinkButton.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/ItemsControl.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/Label.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/ListBox.axaml" />

--- a/Material.Styles/Resources/Themes/HyperlinkButton.axaml
+++ b/Material.Styles/Resources/Themes/HyperlinkButton.axaml
@@ -1,0 +1,59 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:assists="clr-namespace:Material.Styles.Assists">
+
+  <Design.PreviewWith>
+    <Border Padding="20">
+      <StackPanel Spacing="20">
+        <HyperlinkButton Content="Click Me!" />
+      </StackPanel>
+    </Border>
+  </Design.PreviewWith>
+
+  <!-- actual control theme -->
+  <ControlTheme x:Key="MaterialHyperlinkButton" TargetType="HyperlinkButton">
+    <Setter Property="Cursor" Value="Hand" />
+    <Setter Property="TextBlock.TextDecorations" Value="Underline" />
+    <Setter Property="assists:ButtonAssist.IsClicked" Value="False"/>
+    <Setter Property="Template">
+      <ControlTemplate>
+        <ContentPresenter x:Name="PART_ContentPresenter"
+                          Background="{TemplateBinding Background}"
+                          BackgroundSizing="{TemplateBinding BackgroundSizing}"
+                          BorderBrush="{TemplateBinding BorderBrush}"
+                          BorderThickness="{TemplateBinding BorderThickness}"
+                          CornerRadius="{TemplateBinding CornerRadius}"
+                          Content="{TemplateBinding Content}"
+                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                          Padding="{TemplateBinding Padding}"
+                          RecognizesAccessKey="True"
+                          HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                          VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
+      </ControlTemplate>
+    </Setter>
+    
+    <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Foreground" Value="{DynamicResource MaterialHyperlinkBrush}"/>
+      <Setter Property="Opacity" Value="0.8"/>
+    </Style>
+
+    <Style Selector="^:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Opacity" Value="1"/>
+    </Style>
+
+    <Style Selector="^:visited">
+      <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Foreground" Value="{DynamicResource MaterialHyperlinkVisitedBrush}" />
+      </Style>
+    </Style>
+    
+    <Style Selector="^:disabled /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Foreground" Value="{DynamicResource MaterialCheckBoxDisabledColor}"/>
+    </Style>
+  </ControlTheme>
+  
+  <!-- Control theme preference override -->
+  <ControlTheme x:Key="{x:Type HyperlinkButton}"
+                TargetType="HyperlinkButton"
+                BasedOn="{StaticResource MaterialHyperlinkButton}"/>
+</ResourceDictionary>

--- a/Material.Styles/Resources/Themes/ToolTip.axaml
+++ b/Material.Styles/Resources/Themes/ToolTip.axaml
@@ -8,6 +8,7 @@
     <Setter Property="HorizontalAlignment" Value="Center" />
     <Setter Property="HorizontalContentAlignment" Value="Center" />
     <Setter Property="Placement" Value="Pointer" />
+    <Setter Property="TextBlock.TextDecorations" Value="{x:Null}" />
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate>

--- a/Material.Styles/Themes/Base/MaterialPredefinedBaseColors.axaml
+++ b/Material.Styles/Themes/Base/MaterialPredefinedBaseColors.axaml
@@ -31,6 +31,9 @@
       <Color x:Key="MaterialTextAreaBorderColor">#BC000000</Color>
       <Color x:Key="MaterialTextAreaInactiveBorderColor">#0F000000</Color>
       <Color x:Key="MaterialDataGridRowHoverBackgroundColor">#0A000000</Color>
+      
+      <Color x:Key="MaterialHyperlinkColor">#FF1F50D0</Color>
+      <Color x:Key="MaterialHyperlinkVisitedColor">#FF681DA8</Color>
 
       <SolidColorBrush x:Key="MaterialValidationErrorColorBrush" Color="{StaticResource MaterialValidationErrorColor}" />
       <SolidColorBrush x:Key="MaterialBackgroundBrush" Color="{StaticResource MaterialBackgroundColor}" />
@@ -72,6 +75,11 @@
                        Color="{StaticResource MaterialTextAreaInactiveBorderColor}" />
       <SolidColorBrush x:Key="MaterialDataGridRowHoverBackgroundBrush"
                        Color="{StaticResource MaterialDataGridRowHoverBackgroundColor}" />
+      
+      <SolidColorBrush x:Key="MaterialHyperlinkBrush"
+                       Color="{StaticResource MaterialHyperlinkColor}"/>
+      <SolidColorBrush x:Key="MaterialHyperlinkVisitedBrush"
+                       Color="{StaticResource MaterialHyperlinkVisitedColor}"/>
     </ResourceDictionary>
 
     <ResourceDictionary x:Key="{x:Static themes:Theme.MaterialDark}">
@@ -103,6 +111,9 @@
       <Color x:Key="MaterialTextAreaBorderColor">#BCFFFFFF</Color>
       <Color x:Key="MaterialTextAreaInactiveBorderColor">#1AFFFFFF</Color>
       <Color x:Key="MaterialDataGridRowHoverBackgroundColor">#14FFFFFF</Color>
+      
+      <Color x:Key="MaterialHyperlinkColor">#FF7EAAFF</Color>
+      <Color x:Key="MaterialHyperlinkVisitedColor">#FFD19EFA</Color>
 
       <SolidColorBrush x:Key="MaterialValidationErrorColorBrush" Color="{StaticResource MaterialValidationErrorColor}" />
       <SolidColorBrush x:Key="MaterialBackgroundBrush" Color="{StaticResource MaterialBackgroundColor}" />
@@ -144,6 +155,11 @@
                        Color="{StaticResource MaterialTextAreaInactiveBorderColor}" />
       <SolidColorBrush x:Key="MaterialDataGridRowHoverBackgroundBrush"
                        Color="{StaticResource MaterialDataGridRowHoverBackgroundColor}" />
+      
+      <SolidColorBrush x:Key="MaterialHyperlinkBrush"
+                       Color="{StaticResource MaterialHyperlinkColor}"/>
+      <SolidColorBrush x:Key="MaterialHyperlinkVisitedBrush"
+                       Color="{StaticResource MaterialHyperlinkVisitedColor}"/>
     </ResourceDictionary>
   </ResourceDictionary.ThemeDictionaries>
 


### PR DESCRIPTION
# Details

Add Hyperlink themes, which it doesn't existed before.

Static Resource key: `MaterialHyperlinkButton`
Commit: https://github.com/AvaloniaCommunity/Material.Avalonia/commit/d81e934828305331611afc6b3a28a2ba435b4eea

Dark theme
![image](https://github.com/user-attachments/assets/70a6982f-9891-4eae-92f7-8475e2972976)

Light theme
![image](https://github.com/user-attachments/assets/84dd6509-8397-4d6a-bcdb-c0cd8536a667)

Adds two new brushes:
- `MaterialHyperlinkBrush` brush for initial state hyperlinks
- `MaterialHyperlinkVisitedBrush` brush for visited (clicked) state hyperlinks

Adds two new colours:
- `MaterialHyperlinkColor` initial hyperlink colour
- `MaterialHyperlinkVisitedColor` visited hyperlink colour

Commit: https://github.com/AvaloniaCommunity/Material.Avalonia/commit/71fd15ef9e9832b7ad2c5badfeef97244f88451e

Tips: those colours have different between light and dark theme

Also, this PR will update Demo buttons page

