### PR TITLE
Expose RippleEffect.RaiseRipple and RaiseRippleAbsoluteCoord function

### DIFF
--- a/Material.Avalonia.Demo/App.axaml.cs
+++ b/Material.Avalonia.Demo/App.axaml.cs
@@ -1,6 +1,7 @@
 ﻿using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
+using Material.Avalonia.Demo.Assists;
 
 namespace Material.Avalonia.Demo;
 
@@ -10,6 +11,9 @@ public class App : Application {
     }
 
     public override void OnFrameworkInitializationCompleted() {
+        // initiate AutomationAssist to attach events automatically
+        AutomationAssist.Placeholder();
+        
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop) {
             desktop.MainWindow = new MainWindow();
         }

--- a/Material.Avalonia.Demo/Assists/AutomationAssist.cs
+++ b/Material.Avalonia.Demo/Assists/AutomationAssist.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Linq;
+using System.Reactive;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.VisualTree;
+using Material.Ripple;
+using Material.Styles.Assists;
+
+namespace Material.Avalonia.Demo.Assists;
+
+public static class AutomationAssist {
+    #region Initiator (used for observe control changes)
+    
+    // This placeholder is used for anti-optimising to keep it persisted, also triggering static constructor
+    internal static void Placeholder() {
+        Console.WriteLine("Automation assist is initiate...");
+    }
+
+    static AutomationAssist() {
+        Button.ClickEvent.Raised
+            .Subscribe(new AnonymousObserver<(object, RoutedEventArgs)>(OnButtonClickedPrivate));
+    }
+
+    #endregion
+
+    // Used for memorise which hyperlink button clicked (or just say, visited)
+    // this property can be attached to any buttons for use
+    // we have confirmed that this property doesn't need to integrate to the theming library
+    // but it can be used as an example
+    #region AttachedProperty : IsClicked
+
+    public static readonly AvaloniaProperty<bool?> IsClickedProperty =
+        AvaloniaProperty.RegisterAttached<Button, bool?>("IsClicked", typeof(ButtonAssist));
+
+    public static void SetIsClicked(AvaloniaObject element, bool? value) =>
+        element.SetValue(IsClickedProperty, value);
+
+    public static bool? GetIsClicked(AvaloniaObject element) =>
+        element.GetValue<bool?>(IsClickedProperty);
+
+
+    private static void OnButtonClickedPrivate((object, RoutedEventArgs) args) {
+        if (args.Item1 is not Button button)
+            return;
+
+        UpdateIsClickedPropertyPrivate(button);
+        RaiseRipplePrivate(button);
+    }
+
+    internal static void RaiseRipplePrivate(Control c) {
+        // Try to find first RippleEffect control with name PART_Ripple
+        var visual = c
+            .GetVisualDescendants()
+            .FirstOrDefault(a => a is RippleEffect && a.Name == "PART_Ripple");
+
+        // if such control not exist or mouse is over on it 
+        if (visual is not RippleEffect effect || effect.IsPointerOver)
+            return;
+
+        effect.RaiseRipple();
+    }
+
+    private static void UpdateIsClickedPropertyPrivate(Button button) {
+        var value = GetIsClicked(button);
+
+        // null means not required for handling
+        if (!value.HasValue && button is not HyperlinkButton)
+            return;
+
+        value = false;
+        
+        // if IsClickedProperty is false, put it to true
+        if (!value.Value)
+            SetIsClicked(button, true);
+
+        if (button is not HyperlinkButton hyperlink)
+            return;
+
+        // change Hyperlink button is visited state
+        hyperlink.IsVisited = true;
+    }
+
+    #endregion
+}

--- a/Material.Ripple/RippleEffect.cs
+++ b/Material.Ripple/RippleEffect.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
@@ -13,10 +14,7 @@ namespace Material.Ripple {
 
         private CompositionContainerVisual? _container;
         private CompositionCustomVisual? _last;
-        private byte _pointers;
-
-        // TODO: new ripple system, which should deprecate _pointers such thing
-        private static object _lockObj = new();
+        private int _pointers;
 
         static RippleEffect() {
             BackgroundProperty.OverrideDefaultValue<RippleEffect>(Brushes.Transparent);
@@ -86,9 +84,8 @@ namespace Material.Ripple {
             if (_pointers != 0)
                 return;
 
-            lock (_lockObj) {
-                _pointers++;
-            }
+            Interlocked.Increment(ref _pointers);
+
             var r = CreateRipple(x, y, RaiseRippleCenter);
             _last = r;
 
@@ -116,9 +113,7 @@ namespace Material.Ripple {
             if (_last == null)
                 return;
 
-            lock (_lockObj) {
-                _pointers--;
-            }
+            Interlocked.Decrement(ref _pointers);
 
             // This way to handle pointer released is pretty tricky
             // could have more better way to improve

--- a/Material.Ripple/RippleEffect.cs
+++ b/Material.Ripple/RippleEffect.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia;
+﻿using System;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
@@ -56,9 +57,7 @@ namespace Material.Ripple {
         }
 
         private void PointerPressedHandler(object? sender, PointerPressedEventArgs e) {
-            var c = _container;
-
-            if (c is null)
+            if (_container is not {} c)
                 return;
 
             var (x, y) = e.GetPosition(this);
@@ -124,7 +123,7 @@ namespace Material.Ripple {
             var c = _container;
 
             if (c is null || nX < 0 || nX > 1 || nY < 0 || nY > 1)
-                return;
+                throw new ArgumentOutOfRangeException();
 
             lock (this) {
                 if (!IsAllowedRaiseRipple)
@@ -176,8 +175,8 @@ namespace Material.Ripple {
         #region Styled properties
 
         public static readonly StyledProperty<IBrush> RippleFillProperty =
-            AvaloniaProperty.Register<RippleEffect, IBrush>(nameof(RippleFill), inherits: true,
-                defaultValue: Brushes.White);
+            AvaloniaProperty.Register<RippleEffect, IBrush>(nameof(RippleFill), 
+                inherits: true, defaultValue: Brushes.White);
 
         public IBrush RippleFill {
             get => GetValue(RippleFillProperty);

--- a/Material.Styles/Controls/FloatingButton.axaml
+++ b/Material.Styles/Controls/FloatingButton.axaml
@@ -45,7 +45,8 @@
                   MinWidth="{TemplateBinding MinWidth}">
               <Border Name="PART_HoverIndicator"
                       Background="{TemplateBinding assists:ButtonAssist.HoverColor}" />
-              <ripple:RippleEffect RippleFill="{TemplateBinding assists:ButtonAssist.ClickFeedbackColor}"
+              <ripple:RippleEffect Name="PART_Ripple"
+                                   RippleFill="{TemplateBinding assists:ButtonAssist.ClickFeedbackColor}"
                                    RippleOpacity="{StaticResource ButtonPressedOpacity}">
                 <ContentPresenter Name="PART_ContentPresenter"
                                   ContentTemplate="{TemplateBinding ContentTemplate}"


### PR DESCRIPTION
# Details
This will make `RippleEffect` usable as a element that can guide user which things are they looking for, or make it raisable by keyboard or any source.

# Exposed API
- `RippleEffect.RaiseRipple` Raise a ripple element at the coordinate. By default it will raise at center point of the bound of `RippleEffect` control
  - parameter `double nX = 0.5` normalised X coordinate, valid range: [0.0 - 1.0] 
  - parameter `double nY = 0.5` normalised Y coordinate, valid range: [0.0 - 1.0]
- `RippleEffect.RaiseRippleAbsoluteCoord` Raise a ripple element at the non-normalised coordinates. (acquired by https://github.com/AvaloniaCommunity/Material.Avalonia/pull/453#discussion_r2072168285)
  - parameter `double x` X coordinate, should be in bounds of the `RippleEffect`
  - parameter `double y` Y coordinate, should be in bounds of the `RippleEffect`

# Context
https://github.com/AvaloniaCommunity/Material.Avalonia/pull/450#issuecomment-2845424467
https://github.com/AvaloniaCommunity/Material.Avalonia/pull/450#issuecomment-2845609174

# Changes
- Create a `AutomationAssist` class to contains examples for advanced automation usages of the theming library and AvaloniaUI framework, the implementation should be easy to understand, also they cannot be added directly in library but should be "attachable".
- Move `IsClicked` attached property to the `AutomationAssist` of the `Material.Avalonia.Demo`, and add button clicked observer to the `AutomationAssist` , this desicion have been made in PR https://github.com/AvaloniaCommunity/Material.Avalonia/pull/450#pullrequestreview-2810048813 which we should make it as a usage example rather than integrating it to the library
- Correcting `FloatingButton` control template, which the `RippleEffect` didnt have name to satisfy predication of function `RaiseRipplePrivate`
- Refactor `RippleEffect` and expose API `RaiseRipple` and `RaiseRippleAbsoluteCoord`. This API usage will be demonstrated in the demo project.