### PR TITLE
Fix outlined ComboBox border styles

### DIFF
--- a/Material.Styles/Resources/Themes/ComboBox.axaml
+++ b/Material.Styles/Resources/Themes/ComboBox.axaml
@@ -402,6 +402,9 @@
     <Style Selector="^:focus-within">
       <Setter Property="BorderBrush" Value="{DynamicResource MaterialPrimaryMidBrush}" />
       <Setter Property="BorderThickness" Value="2" />
+      <Style Selector="^ /template/ TextBlock#floatingWatermark">
+        <Setter Property="Foreground" Value="{DynamicResource MaterialPrimaryMidBrush}"/>
+      </Style> 
     </Style>
   </ControlTheme>
 </ResourceDictionary>

--- a/Material.Styles/Resources/Themes/ComboBox.axaml
+++ b/Material.Styles/Resources/Themes/ComboBox.axaml
@@ -313,7 +313,6 @@
                       RenderTransformOrigin="0, 0" Opacity="1">
                 <TextBlock Name="floatingWatermark" Classes="Subtitle1"
                            HorizontalAlignment="Stretch" Margin="4,2"
-                           Foreground="{TemplateBinding BorderBrush}"
                            Opacity="{Binding ElementName=PART_Border, Path=Opacity}"
                            Text="{TemplateBinding (assists:ComboBoxAssist.Label)}" />
               </Border>

--- a/Material.Styles/Resources/Themes/ComboBox.axaml
+++ b/Material.Styles/Resources/Themes/ComboBox.axaml
@@ -283,7 +283,7 @@
   <!-- Outline -->
   <ControlTheme x:Key="MaterialOutlineComboBox" TargetType="ComboBox"
                 BasedOn="{StaticResource MaterialComboBox}">
-    <Setter Property="BorderBrush" Value="{DynamicResource MaterialBodyBrush}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource MaterialTextBoxBorderBrush}" />
     <Setter Property="Background" Value="Transparent" />
     <Setter Property="ContextFlyout" Value="{StaticResource DefaultTextBoxMenuFlyout}" />
     <Setter Property="Padding" Value="16,8" />

--- a/Material.Styles/Resources/Themes/ComboBox.axaml
+++ b/Material.Styles/Resources/Themes/ComboBox.axaml
@@ -378,6 +378,15 @@
       </Setter>
     </Style>
 
+    <Style Selector="^:not(.no-transitions) /template/ Border#PART_Border">
+      <Setter Property="Transitions">
+        <Transitions>
+          <BrushTransition Duration="0:0:0.25" Property="BorderBrush" Easing="LinearEasing" />
+          <ThicknessTransition Duration="0:0:0.25" Property="BorderThickness" Easing="CircularEaseOut" />
+        </Transitions>
+      </Setter>
+    </Style> 
+
     <Style Selector="^ /template/ Grid#PART_RootBorder">
       <Setter Property="MinHeight" Value="52" />
     </Style>


### PR DESCRIPTION
Fixed `MaterialOutlineComboBox` control theme.

While using this library, I noticed that the outlined combobox should have lighter colored border brush like the outlined textbox but is body colored.
This fix sets the outlined combobox to the same border brush as the outlined textbox and tweaks the foreground of the label that is affected by it.
Transitions when getting focus were also missing, so I also added them to be like the TextBox.

I am a newbie to Avalonia and Material.Avalonia, so please tell me any mistakes.

|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/bd865e4c-0fcf-4323-b206-6168e1b49560)|![image](https://github.com/user-attachments/assets/380f749c-137a-4219-a289-f8c88dba21d7)|
|![image](https://github.com/user-attachments/assets/1cdf4cd4-e0cc-42a0-855e-0a015cea6389)|![image](https://github.com/user-attachments/assets/1c15498d-df25-4e27-8682-e0c2461551b9)|
|![image](https://github.com/user-attachments/assets/089e5a29-1332-49d6-ad1f-93c7776c254b)|![image](https://github.com/user-attachments/assets/5725f703-ea9a-4f4a-ab6d-ca45a2a256df)|
