### PR TITLE
Add some missing control themes (SplitButton, DropDownButton, ManagedFileChooser), correct FlyoutPresenter

### DIFF
--- a/Material.Avalonia.Demo.Desktop/Program.cs
+++ b/Material.Avalonia.Demo.Desktop/Program.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using Avalonia;
+using Avalonia.Dialogs;
 using ShowMeTheXaml;
 
 namespace Material.Avalonia.Demo.Desktop {
@@ -15,6 +17,8 @@ namespace Material.Avalonia.Demo.Desktop {
         }
 
         // Avalonia configuration, don't remove; also used by visual designer.
+        // CA1416: only Desktop platform supported (Windows, Linux, macOS)
+        [SuppressMessage("Interoperability", "CA1416")]
         public static AppBuilder BuildAvaloniaApp() {
             return AppBuilder.Configure<App>()
                 .LogToTrace()
@@ -24,6 +28,7 @@ namespace Material.Avalonia.Demo.Desktop {
                     UseDBusMenu = true,
                     EnableIme = true
                 })
+                .UseManagedSystemDialogs()
                 .UseXamlDisplay();
         }
     }

--- a/Material.Avalonia.Demo/Pages/ButtonsDemo.axaml
+++ b/Material.Avalonia.Demo/Pages/ButtonsDemo.axaml
@@ -6,12 +6,21 @@
              xmlns:avalonia="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
              xmlns:controls="clr-namespace:Material.Styles.Controls;assembly=Material.Styles"
              xmlns:showMeTheXaml="clr-namespace:ShowMeTheXaml;assembly=ShowMeTheXaml.Avalonia"
-             xmlns:assists="clr-namespace:Material.Styles.Assists;assembly=Material.Styles"
              x:Class="Material.Avalonia.Demo.Pages.ButtonsDemo"
              Name="ButtonsDemoPageControl">
   <StackPanel Margin="16, 0">
     <StackPanel.Styles>
       <Style Selector="Button">
+        <Setter Property="IsEnabled"
+                Value="{Binding ElementName=IsEnabledCheckBox, Path=IsChecked}" />
+      </Style>
+      
+      <Style Selector="SplitButton">
+        <Setter Property="IsEnabled"
+                Value="{Binding ElementName=IsEnabledCheckBox, Path=IsChecked}" />
+      </Style>
+      
+      <Style Selector="DropDownButton">
         <Setter Property="IsEnabled"
                 Value="{Binding ElementName=IsEnabledCheckBox, Path=IsChecked}" />
       </Style>
@@ -171,6 +180,7 @@
       <showMeTheXaml:XamlDisplay UniqueId="ExpandedFloatingButton3">
         <controls:FloatingButton Classes="Accent" IsExtended="{Binding ElementName=CheckBox1, Path=IsChecked}" />
       </showMeTheXaml:XamlDisplay>
+      
       <CheckBox Name="CheckBox1" Content="IsExtended" Margin="16,8" />
     </StackPanel>
 
@@ -217,28 +227,28 @@
         <showMeTheXaml:XamlDisplay UniqueId="SplitButtons0">
           <SplitButton Theme="{StaticResource MaterialSplitButton}"
                        Classes="up light"
-                       Content="Default"
+                       Content="Light"
                        ToolTip.Tip='Split button' Flyout="{StaticResource SharedSplitButtonMenuFlyout}" />
         </showMeTheXaml:XamlDisplay>
       
         <showMeTheXaml:XamlDisplay UniqueId="SplitButtons1">
           <SplitButton Theme="{StaticResource MaterialSplitButton}"
                        Classes="up"
-                       Content="Default"
+                       Content="Mid (Default)"
                        ToolTip.Tip='Split button' Flyout="{StaticResource SharedSplitButtonMenuFlyout}" />
         </showMeTheXaml:XamlDisplay>
       
         <showMeTheXaml:XamlDisplay UniqueId="SplitButtons2">
           <SplitButton Theme="{StaticResource MaterialSplitButton}"
                        Classes="up dark"
-                       Content="Default"
+                       Content="Dark"
                        ToolTip.Tip='Split button' Flyout="{StaticResource SharedSplitButtonMenuFlyout}" />
         </showMeTheXaml:XamlDisplay>
       
         <showMeTheXaml:XamlDisplay UniqueId="SplitButtons3">
           <SplitButton Theme="{StaticResource MaterialSplitButton}"
                        Classes="up accent"
-                       Content="Default"
+                       Content="Accent"
                        ToolTip.Tip='Split button' Flyout="{StaticResource SharedSplitButtonMenuFlyout}" />
         </showMeTheXaml:XamlDisplay>
       </StackPanel>
@@ -247,7 +257,7 @@
         <showMeTheXaml:XamlDisplay UniqueId="OutlineSplitButtons0">
           <SplitButton Theme="{StaticResource MaterialOutlineSplitButton}"
                        Classes="up light"
-                       Content="Default"
+                       Content="Light"
                        ToolTip.Tip='Split button' Flyout="{StaticResource SharedSplitButtonMenuFlyout}" />
         </showMeTheXaml:XamlDisplay>
       
@@ -261,17 +271,60 @@
         <showMeTheXaml:XamlDisplay UniqueId="OutlineSplitButtons2">
           <SplitButton Theme="{StaticResource MaterialOutlineSplitButton}"
                        Classes="up dark"
-                       Content="Default"
+                       Content="Dark"
                        ToolTip.Tip='Split button' Flyout="{StaticResource SharedSplitButtonMenuFlyout}" />
         </showMeTheXaml:XamlDisplay>
       
         <showMeTheXaml:XamlDisplay UniqueId="OutlineSplitButtons3">
           <SplitButton Theme="{StaticResource MaterialOutlineSplitButton}"
                        Classes="up accent"
-                       Content="Default"
+                       Content="Accent"
                        ToolTip.Tip='Split button' Flyout="{StaticResource SharedSplitButtonMenuFlyout}" />
         </showMeTheXaml:XamlDisplay>
       </StackPanel>
+    </StackPanel>
+    
+    <TextBlock Classes="Headline6 Subheadline2" Text="DropDown buttons" />
+    <StackPanel Orientation="Horizontal">
+      <StackPanel.Styles>
+        <Style Selector="showMeTheXaml|XamlDisplay">
+          <Setter Property="Margin" Value="8" />
+        </Style>
+      </StackPanel.Styles>
+      <showMeTheXaml:XamlDisplay UniqueId="DropDownButtons0">
+        <DropDownButton Theme="{StaticResource MaterialDropDownButton}" Classes="light" Content="Light" ToolTip.Tip='Button with classes "Light" and "Outline"' />
+      </showMeTheXaml:XamlDisplay>
+      <showMeTheXaml:XamlDisplay UniqueId="DropDownButtons1">
+        <DropDownButton Theme="{StaticResource MaterialDropDownButton}" Content="Mid (Default)" ToolTip.Tip='Button with classes "Outline"' />
+      </showMeTheXaml:XamlDisplay>
+      <showMeTheXaml:XamlDisplay UniqueId="DropDownButtons2">
+        <DropDownButton Theme="{StaticResource MaterialDropDownButton}" Classes="dark" Content="Dark" ToolTip.Tip='Button with classes "Dark" and "Outline"' />
+      </showMeTheXaml:XamlDisplay>
+      <showMeTheXaml:XamlDisplay UniqueId="DropDownButtons3">
+        <DropDownButton Theme="{StaticResource MaterialDropDownButton}" Classes="accent" Content="Accent"
+                        ToolTip.Tip='Button with classes "Accent" and "Outline"' />
+      </showMeTheXaml:XamlDisplay>
+    </StackPanel>
+    
+    <StackPanel Orientation="Horizontal">
+      <StackPanel.Styles>
+        <Style Selector="showMeTheXaml|XamlDisplay">
+          <Setter Property="Margin" Value="8" />
+        </Style>
+      </StackPanel.Styles>
+      <showMeTheXaml:XamlDisplay UniqueId="OutlineDropDownButtons0">
+        <DropDownButton Theme="{StaticResource MaterialOutlineDropDownButton}" Classes="light" Content="Light" ToolTip.Tip='Button with classes "Light" and "Outline"' />
+      </showMeTheXaml:XamlDisplay>
+      <showMeTheXaml:XamlDisplay UniqueId="OutlineDropDownButtons1">
+        <DropDownButton Theme="{StaticResource MaterialOutlineDropDownButton}" Content="Mid (Default)" ToolTip.Tip='Button with classes "Outline"' />
+      </showMeTheXaml:XamlDisplay>
+      <showMeTheXaml:XamlDisplay UniqueId="OutlineDropDownButtons2">
+        <DropDownButton Theme="{StaticResource MaterialOutlineDropDownButton}" Classes="dark" Content="Dark" ToolTip.Tip='Button with classes "Dark" and "Outline"' />
+      </showMeTheXaml:XamlDisplay>
+      <showMeTheXaml:XamlDisplay UniqueId="OutlineDropDownButtons3">
+        <DropDownButton Theme="{StaticResource MaterialOutlineDropDownButton}" Classes="accent" Content="Accent"
+                        ToolTip.Tip='Button with classes "Accent" and "Outline"' />
+      </showMeTheXaml:XamlDisplay>
     </StackPanel>
 
     <TextBlock Classes="Headline6 Subheadline2" Text="Hyperlink buttons" />

--- a/Material.Avalonia.Demo/Pages/ButtonsDemo.axaml
+++ b/Material.Avalonia.Demo/Pages/ButtonsDemo.axaml
@@ -217,6 +217,19 @@
                     InputGesture="Ctrl+A" />
           <MenuItem Header="Item 3" />
         </MenuFlyout>
+        
+        <MenuFlyout x:Key="SharedDownSplitButtonMenuFlyout"
+                    HorizontalOffset="8" VerticalOffset="-8"
+                    Placement="BottomEdgeAlignedRight">
+          <MenuItem Header="Item 1">
+            <MenuItem Header="Subitem 1" />
+            <MenuItem Header="Subitem 2" />
+            <MenuItem Header="Subitem 3" />
+          </MenuItem>
+          <MenuItem Header="Item 2"
+                    InputGesture="Ctrl+A" />
+          <MenuItem Header="Item 3" />
+        </MenuFlyout>
       </StackPanel.Resources>
       <StackPanel.Styles>
         <Style Selector="showMeTheXaml|XamlDisplay">
@@ -247,9 +260,9 @@
       
         <showMeTheXaml:XamlDisplay UniqueId="SplitButtons3">
           <SplitButton Theme="{StaticResource MaterialSplitButton}"
-                       Classes="up accent"
+                       Classes="down accent"
                        Content="Accent"
-                       ToolTip.Tip='Split button' Flyout="{StaticResource SharedSplitButtonMenuFlyout}" />
+                       ToolTip.Tip='Split button' Flyout="{StaticResource SharedDownSplitButtonMenuFlyout}" />
         </showMeTheXaml:XamlDisplay>
       </StackPanel>
       
@@ -277,52 +290,80 @@
       
         <showMeTheXaml:XamlDisplay UniqueId="OutlineSplitButtons3">
           <SplitButton Theme="{StaticResource MaterialOutlineSplitButton}"
-                       Classes="up accent"
+                       Classes="down accent"
                        Content="Accent"
-                       ToolTip.Tip='Split button' Flyout="{StaticResource SharedSplitButtonMenuFlyout}" />
+                       ToolTip.Tip='Split button' Flyout="{StaticResource SharedDownSplitButtonMenuFlyout}" />
         </showMeTheXaml:XamlDisplay>
       </StackPanel>
     </StackPanel>
     
     <TextBlock Classes="Headline6 Subheadline2" Text="DropDown buttons" />
     <StackPanel Orientation="Horizontal">
+      <StackPanel.Resources>
+        <MenuFlyout x:Key="SharedSplitButtonMenuFlyout"
+                    HorizontalOffset="8" VerticalOffset="-8"
+                    Placement="BottomEdgeAlignedRight">
+          <MenuItem Header="Item 1">
+            <MenuItem Header="Subitem 1" />
+            <MenuItem Header="Subitem 2" />
+            <MenuItem Header="Subitem 3" />
+          </MenuItem>
+          <MenuItem Header="Item 2"
+                    InputGesture="Ctrl+A" />
+          <MenuItem Header="Item 3" />
+        </MenuFlyout>
+      </StackPanel.Resources>
       <StackPanel.Styles>
         <Style Selector="showMeTheXaml|XamlDisplay">
           <Setter Property="Margin" Value="8" />
         </Style>
       </StackPanel.Styles>
       <showMeTheXaml:XamlDisplay UniqueId="DropDownButtons0">
-        <DropDownButton Theme="{StaticResource MaterialDropDownButton}" Classes="light" Content="Light" ToolTip.Tip='Button with classes "Light" and "Outline"' />
+        <DropDownButton Theme="{StaticResource MaterialDropDownButton}" Classes="light" Content="Light" Flyout="{StaticResource SharedSplitButtonMenuFlyout}" ToolTip.Tip='Button with classes "Light" and "Outline"' />
       </showMeTheXaml:XamlDisplay>
       <showMeTheXaml:XamlDisplay UniqueId="DropDownButtons1">
-        <DropDownButton Theme="{StaticResource MaterialDropDownButton}" Content="Mid (Default)" ToolTip.Tip='Button with classes "Outline"' />
+        <DropDownButton Theme="{StaticResource MaterialDropDownButton}" Content="Mid (Default)" Flyout="{StaticResource SharedSplitButtonMenuFlyout}" ToolTip.Tip='Button with classes "Outline"' />
       </showMeTheXaml:XamlDisplay>
       <showMeTheXaml:XamlDisplay UniqueId="DropDownButtons2">
-        <DropDownButton Theme="{StaticResource MaterialDropDownButton}" Classes="dark" Content="Dark" ToolTip.Tip='Button with classes "Dark" and "Outline"' />
+        <DropDownButton Theme="{StaticResource MaterialDropDownButton}" Classes="dark" Content="Dark" Flyout="{StaticResource SharedSplitButtonMenuFlyout}" ToolTip.Tip='Button with classes "Dark" and "Outline"' />
       </showMeTheXaml:XamlDisplay>
       <showMeTheXaml:XamlDisplay UniqueId="DropDownButtons3">
-        <DropDownButton Theme="{StaticResource MaterialDropDownButton}" Classes="accent" Content="Accent"
+        <DropDownButton Theme="{StaticResource MaterialDropDownButton}" Classes="accent" Content="Accent" Flyout="{StaticResource SharedSplitButtonMenuFlyout}"
                         ToolTip.Tip='Button with classes "Accent" and "Outline"' />
       </showMeTheXaml:XamlDisplay>
     </StackPanel>
     
     <StackPanel Orientation="Horizontal">
+      <StackPanel.Resources>
+        <MenuFlyout x:Key="SharedSplitButtonMenuFlyout"
+                    HorizontalOffset="8" VerticalOffset="-8"
+                    Placement="BottomEdgeAlignedRight">
+          <MenuItem Header="Item 1">
+            <MenuItem Header="Subitem 1" />
+            <MenuItem Header="Subitem 2" />
+            <MenuItem Header="Subitem 3" />
+          </MenuItem>
+          <MenuItem Header="Item 2"
+                    InputGesture="Ctrl+A" />
+          <MenuItem Header="Item 3" />
+        </MenuFlyout>
+      </StackPanel.Resources>
       <StackPanel.Styles>
         <Style Selector="showMeTheXaml|XamlDisplay">
           <Setter Property="Margin" Value="8" />
         </Style>
       </StackPanel.Styles>
       <showMeTheXaml:XamlDisplay UniqueId="OutlineDropDownButtons0">
-        <DropDownButton Theme="{StaticResource MaterialOutlineDropDownButton}" Classes="light" Content="Light" ToolTip.Tip='Button with classes "Light" and "Outline"' />
+        <DropDownButton Theme="{StaticResource MaterialOutlineDropDownButton}" Classes="light" Content="Light" Flyout="{StaticResource SharedSplitButtonMenuFlyout}" ToolTip.Tip='Button with classes "Light" and "Outline"' />
       </showMeTheXaml:XamlDisplay>
       <showMeTheXaml:XamlDisplay UniqueId="OutlineDropDownButtons1">
-        <DropDownButton Theme="{StaticResource MaterialOutlineDropDownButton}" Content="Mid (Default)" ToolTip.Tip='Button with classes "Outline"' />
+        <DropDownButton Theme="{StaticResource MaterialOutlineDropDownButton}" Content="Mid (Default)" Flyout="{StaticResource SharedSplitButtonMenuFlyout}" ToolTip.Tip='Button with classes "Outline"' />
       </showMeTheXaml:XamlDisplay>
       <showMeTheXaml:XamlDisplay UniqueId="OutlineDropDownButtons2">
-        <DropDownButton Theme="{StaticResource MaterialOutlineDropDownButton}" Classes="dark" Content="Dark" ToolTip.Tip='Button with classes "Dark" and "Outline"' />
+        <DropDownButton Theme="{StaticResource MaterialOutlineDropDownButton}" Classes="dark" Content="Dark" Flyout="{StaticResource SharedSplitButtonMenuFlyout}" ToolTip.Tip='Button with classes "Dark" and "Outline"' />
       </showMeTheXaml:XamlDisplay>
       <showMeTheXaml:XamlDisplay UniqueId="OutlineDropDownButtons3">
-        <DropDownButton Theme="{StaticResource MaterialOutlineDropDownButton}" Classes="accent" Content="Accent"
+        <DropDownButton Theme="{StaticResource MaterialOutlineDropDownButton}" Classes="accent" Content="Accent" Flyout="{StaticResource SharedSplitButtonMenuFlyout}"
                         ToolTip.Tip='Button with classes "Accent" and "Outline"' />
       </showMeTheXaml:XamlDisplay>
     </StackPanel>

--- a/Material.Avalonia.Demo/Pages/ButtonsDemo.axaml
+++ b/Material.Avalonia.Demo/Pages/ButtonsDemo.axaml
@@ -191,6 +191,88 @@
         <Button Theme="{StaticResource MaterialFlatButton}" Classes="accent" Content="Accent" ToolTip.Tip='Button with classes "Accent" and "Flat"' />
       </showMeTheXaml:XamlDisplay>
     </StackPanel>
+    
+    <TextBlock Classes="Headline6 Subheadline2" Text="Split buttons" />
+    <StackPanel>
+      <StackPanel.Resources>
+        <MenuFlyout x:Key="SharedSplitButtonMenuFlyout"
+                    HorizontalOffset="8" VerticalOffset="8"
+                    Placement="TopEdgeAlignedRight">
+          <MenuItem Header="Item 1">
+            <MenuItem Header="Subitem 1" />
+            <MenuItem Header="Subitem 2" />
+            <MenuItem Header="Subitem 3" />
+          </MenuItem>
+          <MenuItem Header="Item 2"
+                    InputGesture="Ctrl+A" />
+          <MenuItem Header="Item 3" />
+        </MenuFlyout>
+      </StackPanel.Resources>
+      <StackPanel.Styles>
+        <Style Selector="showMeTheXaml|XamlDisplay">
+          <Setter Property="Margin" Value="8" />
+        </Style>
+      </StackPanel.Styles>
+      <StackPanel Orientation="Horizontal">
+        <showMeTheXaml:XamlDisplay UniqueId="SplitButtons0">
+          <SplitButton Theme="{StaticResource MaterialSplitButton}"
+                       Classes="up light"
+                       Content="Default"
+                       ToolTip.Tip='Split button' Flyout="{StaticResource SharedSplitButtonMenuFlyout}" />
+        </showMeTheXaml:XamlDisplay>
+      
+        <showMeTheXaml:XamlDisplay UniqueId="SplitButtons1">
+          <SplitButton Theme="{StaticResource MaterialSplitButton}"
+                       Classes="up"
+                       Content="Default"
+                       ToolTip.Tip='Split button' Flyout="{StaticResource SharedSplitButtonMenuFlyout}" />
+        </showMeTheXaml:XamlDisplay>
+      
+        <showMeTheXaml:XamlDisplay UniqueId="SplitButtons2">
+          <SplitButton Theme="{StaticResource MaterialSplitButton}"
+                       Classes="up dark"
+                       Content="Default"
+                       ToolTip.Tip='Split button' Flyout="{StaticResource SharedSplitButtonMenuFlyout}" />
+        </showMeTheXaml:XamlDisplay>
+      
+        <showMeTheXaml:XamlDisplay UniqueId="SplitButtons3">
+          <SplitButton Theme="{StaticResource MaterialSplitButton}"
+                       Classes="up accent"
+                       Content="Default"
+                       ToolTip.Tip='Split button' Flyout="{StaticResource SharedSplitButtonMenuFlyout}" />
+        </showMeTheXaml:XamlDisplay>
+      </StackPanel>
+      
+      <StackPanel Orientation="Horizontal">
+        <showMeTheXaml:XamlDisplay UniqueId="OutlineSplitButtons0">
+          <SplitButton Theme="{StaticResource MaterialOutlineSplitButton}"
+                       Classes="up light"
+                       Content="Default"
+                       ToolTip.Tip='Split button' Flyout="{StaticResource SharedSplitButtonMenuFlyout}" />
+        </showMeTheXaml:XamlDisplay>
+      
+        <showMeTheXaml:XamlDisplay UniqueId="OutlineSplitButtons1">
+          <SplitButton Theme="{StaticResource MaterialOutlineSplitButton}"
+                       Classes="up"
+                       Content="Default"
+                       ToolTip.Tip='Split button' Flyout="{StaticResource SharedSplitButtonMenuFlyout}" />
+        </showMeTheXaml:XamlDisplay>
+      
+        <showMeTheXaml:XamlDisplay UniqueId="OutlineSplitButtons2">
+          <SplitButton Theme="{StaticResource MaterialOutlineSplitButton}"
+                       Classes="up dark"
+                       Content="Default"
+                       ToolTip.Tip='Split button' Flyout="{StaticResource SharedSplitButtonMenuFlyout}" />
+        </showMeTheXaml:XamlDisplay>
+      
+        <showMeTheXaml:XamlDisplay UniqueId="OutlineSplitButtons3">
+          <SplitButton Theme="{StaticResource MaterialOutlineSplitButton}"
+                       Classes="up accent"
+                       Content="Default"
+                       ToolTip.Tip='Split button' Flyout="{StaticResource SharedSplitButtonMenuFlyout}" />
+        </showMeTheXaml:XamlDisplay>
+      </StackPanel>
+    </StackPanel>
 
     <TextBlock Classes="Headline6 Subheadline2" Text="Hyperlink buttons" />
     <StackPanel Orientation="Horizontal" Spacing="8">

--- a/Material.Avalonia.Demo/Pages/DialogDemo.axaml
+++ b/Material.Avalonia.Demo/Pages/DialogDemo.axaml
@@ -17,8 +17,14 @@
   </UserControl.Resources>
 
   <StackPanel Margin="16, 0">
+    <StackPanel.Styles>
+      <Style Selector="WrapPanel#ModulesRoot > StackPanel">
+        <Setter Property="MaxWidth" Value="360"/>
+      </Style>
+    </StackPanel.Styles>
+    
     <TextBlock Classes="Headline4 Subheadline" Text="Dialogs" />
-    <Grid ColumnDefinitions="*, *">
+    <WrapPanel Name="ModulesRoot">
 
       <StackPanel>
         <TextBlock Classes="Headline6 Subheadline2" Text="DialogHost" />
@@ -32,7 +38,7 @@
         </StackPanel>
       </StackPanel>
 
-      <StackPanel Grid.Column="1">
+      <StackPanel>
         <TextBlock Classes="Headline6 Subheadline2" Text="Standalone dialog" />
 
         <TextBlock IsVisible="{Binding !IsDialogsAvailable}">
@@ -66,7 +72,12 @@
           </ItemsControl.ItemTemplate>
         </ItemsControl>
       </StackPanel>
-    </Grid>
+      
+      <StackPanel>
+        <TextBlock Classes="Headline6 Subheadline2" Text="Managed file picker" />
+        <Button Classes="flat" Content="Example" Click="FilePickerExampleButton_OnClick"/>
+      </StackPanel>
+    </WrapPanel>
   </StackPanel>
 
 

--- a/Material.Avalonia.Demo/Pages/DialogDemo.axaml.cs
+++ b/Material.Avalonia.Demo/Pages/DialogDemo.axaml.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Interactivity;
+using Avalonia.Platform.Storage;
 using DialogHostAvalonia;
 using Material.Avalonia.Demo.Models;
 using Material.Avalonia.Demo.ViewModels;
@@ -32,5 +33,16 @@ public partial class DialogDemo : UserControl {
 
     private void OpenMoreDialogHostExamples(object? sender, RoutedEventArgs e) {
         Process.Start(new ProcessStartInfo { FileName = "https://github.com/AvaloniaUtils/DialogHost.Avalonia", UseShellExecute = true });
+    }
+
+    private async void FilePickerExampleButton_OnClick(object? sender, RoutedEventArgs e) {
+        var toplevel = TopLevel.GetTopLevel(this);
+        var folders = await toplevel!
+            .StorageProvider
+            .OpenFolderPickerAsync(new FolderPickerOpenOptions
+        {
+            Title = "Folder file",
+            SuggestedFileName = "FileName",
+        });
     }
 }

--- a/Material.Styles/MaterialToolKit.xaml
+++ b/Material.Styles/MaterialToolKit.xaml
@@ -43,6 +43,7 @@
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/ContextMenu.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/DataValidationErrors.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/DatePicker.axaml" />
+        <ResourceInclude Source="avares://Material.Styles/Resources/Themes/DropDownButton.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/EmbeddableControlRoot.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/Expander.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/FlyoutPresenter.axaml" />
@@ -53,6 +54,7 @@
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/Label.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/ListBox.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/ListBoxItem.axaml" />
+        <ResourceInclude Source="avares://Material.Styles/Resources/Themes/ManagedFileChooser.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/Menu.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/MenuFlyoutPresenter.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/MenuItem.axaml" />

--- a/Material.Styles/MaterialToolKit.xaml
+++ b/Material.Styles/MaterialToolKit.xaml
@@ -73,6 +73,7 @@
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/SelectableTextBlock.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/Separator.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/Slider.axaml" />
+        <ResourceInclude Source="avares://Material.Styles/Resources/Themes/SplitButton.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/SplitView.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/TabControl.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/TabItem.axaml" />

--- a/Material.Styles/Resources/Themes/DropDownButton.axaml
+++ b/Material.Styles/Resources/Themes/DropDownButton.axaml
@@ -2,8 +2,6 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:ripple="clr-namespace:Material.Ripple;assembly=Material.Ripple"
                     xmlns:assists="clr-namespace:Material.Styles.Assists">
-  <!-- Add Resources Here -->
-
   <ControlTheme x:Key="MaterialDropDownButton"
                 BasedOn="{StaticResource MaterialButtonBase}"
                 TargetType="DropDownButton">

--- a/Material.Styles/Resources/Themes/DropDownButton.axaml
+++ b/Material.Styles/Resources/Themes/DropDownButton.axaml
@@ -1,0 +1,104 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:ripple="clr-namespace:Material.Ripple;assembly=Material.Ripple"
+                    xmlns:assists="clr-namespace:Material.Styles.Assists">
+  <!-- Add Resources Here -->
+
+  <ControlTheme x:Key="MaterialDropDownButton"
+                BasedOn="{StaticResource MaterialButtonBase}"
+                TargetType="DropDownButton">
+    <Setter Property="ClipToBounds" Value="False"/>
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Border Name="PART_RootBorder"
+                Background="{TemplateBinding Background}"
+                BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="{TemplateBinding BorderThickness}"
+                CornerRadius="{TemplateBinding CornerRadius}"
+                assists:ShadowAssist.ShadowDepth="{TemplateBinding assists:ShadowAssist.ShadowDepth}">
+          <Panel Name="PART_RootPanel">
+            <Border Name="PART_HoverEffect"
+                    Background="{TemplateBinding assists:ButtonAssist.HoverColor}"
+                    CornerRadius="{TemplateBinding CornerRadius}" />
+            <Border CornerRadius="{TemplateBinding CornerRadius}"
+                    ClipToBounds="True">
+              <ripple:RippleEffect Name="PART_Ripple"
+                                   RippleFill="{TemplateBinding assists:ButtonAssist.ClickFeedbackColor}"
+                                   RippleOpacity="{StaticResource ButtonPressedOpacity}">
+                <Grid Name="PART_Grid" ColumnDefinitions="*, Auto">
+                  <ContentPresenter Name="PART_ContentPresenter"
+                                    Content="{TemplateBinding Content}"
+                                    ContentTemplate="{TemplateBinding ContentTemplate}"
+                                    Padding="{TemplateBinding Padding}"
+                                    RecognizesAccessKey="True"
+                                    HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                    VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
+
+                  <Path Grid.Column="1"
+                        Data="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
+                        Width="24" Height="24"
+                        Name="ExpandPath"/>
+                </Grid>
+
+              </ripple:RippleEffect>
+            </Border>
+          </Panel>
+        </Border>
+      </ControlTemplate>
+    </Setter>
+    
+    <Setter Property="Background" Value="{DynamicResource MaterialPrimaryMidBrush}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource MaterialPrimaryMidBrush}" />
+    <Setter Property="Foreground" Value="{DynamicResource MaterialPrimaryMidForegroundBrush}" />
+    <Setter Property="assists:ShadowAssist.ShadowDepth" Value="Depth1" />
+    
+    <!-- Apply patch to icon -->
+    <Style Selector="^ /template/ Path#ExpandPath">
+      <Setter Property="Fill" Value="{TemplateBinding TemplatedControl.Foreground}" />
+      <Setter Property="Margin" Value="4"/>
+      <Setter Property="RenderTransform" Value="rotate(90deg)"/>
+    </Style>
+  </ControlTheme>
+  
+  <ControlTheme x:Key="MaterialOutlineDropDownButton"
+                BasedOn="{StaticResource MaterialDropDownButton}"
+                TargetType="DropDownButton">
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="BorderBrush" Value="{DynamicResource MaterialPrimaryMidBrush}" />
+    <Setter Property="Foreground" Value="{DynamicResource MaterialPrimaryMidBrush}" />
+    <Setter Property="Padding" Value="16 6" />
+    <Setter Property="assists:ShadowAssist.ShadowDepth" Value="Depth0" />
+
+    <!-- Colour variants -->
+
+    <Style Selector="^.accent">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="BorderBrush" Value="{DynamicResource MaterialSecondaryMidBrush}" />
+      <Setter Property="Foreground" Value="{DynamicResource MaterialSecondaryMidBrush}" />
+    </Style>
+
+    <Style Selector="^.light">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="BorderBrush" Value="{DynamicResource MaterialPrimaryLightBrush}" />
+      <Setter Property="Foreground" Value="{DynamicResource MaterialPrimaryLightBrush}" />
+    </Style>
+
+    <Style Selector="^.dark">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="BorderBrush" Value="{DynamicResource MaterialPrimaryDarkBrush}" />
+      <Setter Property="Foreground" Value="{DynamicResource MaterialPrimaryDarkBrush}" />
+    </Style>
+
+
+    <Style Selector="^:disabled">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="BorderBrush" Value="{DynamicResource MaterialBodyBrush}" />
+      <Setter Property="Foreground" Value="{DynamicResource MaterialBodyBrush}" />
+    </Style>
+  </ControlTheme>
+  
+  <ControlTheme x:Key="{x:Type DropDownButton}"
+                BasedOn="{StaticResource MaterialDropDownButton}"
+                TargetType="DropDownButton"/>
+</ResourceDictionary>

--- a/Material.Styles/Resources/Themes/FlyoutPresenter.axaml
+++ b/Material.Styles/Resources/Themes/FlyoutPresenter.axaml
@@ -4,6 +4,7 @@
   <x:Double x:Key="FlyoutThemeMaxWidth">456</x:Double>
   <x:Double x:Key="FlyoutThemeMaxHeight">758</x:Double>
   <ControlTheme x:Key="MaterialFlyoutPresenter" TargetType="FlyoutPresenter">
+    <Setter Property="Background" Value="{DynamicResource MaterialPaperBrush}" />
     <Setter Property="HorizontalContentAlignment" Value="Stretch" />
     <Setter Property="VerticalContentAlignment" Value="Stretch" />
     <Setter Property="Padding" Value="8" />

--- a/Material.Styles/Resources/Themes/ManagedFileChooser.axaml
+++ b/Material.Styles/Resources/Themes/ManagedFileChooser.axaml
@@ -3,7 +3,6 @@
                     xmlns:converters="clr-namespace:Avalonia.Controls.Converters;assembly=Avalonia.Controls"
                     xmlns:dialogs="clr-namespace:Avalonia.Dialogs;assembly=Avalonia.Dialogs"
                     xmlns:internal="clr-namespace:Avalonia.Dialogs.Internal;assembly=Avalonia.Dialogs">
-  <!-- TODO: make this file picker usable in DialogHost -->
   <ControlTheme x:Key="{x:Type dialogs:ManagedFileChooser}" TargetType="dialogs:ManagedFileChooser">
     <ControlTheme.Resources>
       <ResourceDictionary>

--- a/Material.Styles/Resources/Themes/ManagedFileChooser.axaml
+++ b/Material.Styles/Resources/Themes/ManagedFileChooser.axaml
@@ -1,0 +1,397 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:converters="clr-namespace:Avalonia.Controls.Converters;assembly=Avalonia.Controls"
+                    xmlns:dialogs="clr-namespace:Avalonia.Dialogs;assembly=Avalonia.Dialogs"
+                    xmlns:internal="clr-namespace:Avalonia.Dialogs.Internal;assembly=Avalonia.Dialogs">
+  <!-- TODO: make this file picker usable in DialogHost -->
+  <ControlTheme x:Key="{x:Type dialogs:ManagedFileChooser}" TargetType="dialogs:ManagedFileChooser">
+    <ControlTheme.Resources>
+      <ResourceDictionary>
+        <GradientStops x:Key="IconRes.FolderBackGradientStops">
+        </GradientStops>
+        <GradientStops x:Key="IconRes.FolderFrontGradientStops">
+          <GradientStop Offset="0" Color="#FFFFDA6F"/>
+          <GradientStop Offset="1" Color="#FFFEC326"/>
+        </GradientStops>
+        <DrawingGroup x:Key="LevelUp">
+          <GeometryDrawing Brush="#00FFFFFF" Geometry="F1M16,16L0,16 0,0 16,0z" />
+          <GeometryDrawing Brush="#FFF6F6F6" Geometry="F1M14.5,0L6.39,0 5.39,2 2.504,2C1.677,2,1,2.673,1,3.5L1,10.582 1,10.586 1,15.414 3,13.414 3,16 7,16 7,13.414 9,15.414 9,13 14.5,13C15.327,13,16,12.327,16,11.5L16,1.5C16,0.673,15.327,0,14.5,0" />
+          <GeometryDrawing Brush="#FFDCB679" Geometry="F1M14,3L7.508,3 8.008,2 8.012,2 14,2z M14.5,1L7.008,1 6.008,3 2.504,3C2.227,3,2,3.224,2,3.5L2,9.582 4.998,6.586 9,10.586 9,12 14.5,12C14.775,12,15,11.776,15,11.5L15,1.5C15,1.224,14.775,1,14.5,1" />
+          <GeometryDrawing Brush="#FF00529C" Geometry="F1M8,11L5,8 2,11 2,13 4,11 4,15 6,15 6,11 8,13z" />
+          <GeometryDrawing Brush="#FFF0EFF1" Geometry="F1M8.0001,1.9996L7.5001,3.0006 14.0001,3.0006 14.0001,1.9996z" />
+        </DrawingGroup>
+        <internal:ResourceSelectorConverter x:Key="Icons">
+          <DrawingGroup x:Key="Icon_Folder">
+            <GeometryDrawing Geometry="M 0 0 L 16 16"/>
+            <GeometryDrawing Geometry="M 0 3 C 0,1 0,1 2,1 L 5 1 C 5.5,1 6,1 6.5,1.5 L 8 3 L 14 3 C 16,3 16,3 16,5
+                        L 16,12 C 16,14 16,14 14,14
+                        L 2,14 C 0,14 0,14 0,12 Z">
+              <GeometryDrawing.Brush>
+                <LinearGradientBrush StartPoint="1,4" EndPoint="23,20">
+                  <GradientStop Offset="0" Color="#FFFFC018"/>
+                  <GradientStop Offset="1" Color="#FFDFA32D"/>
+                </LinearGradientBrush>
+              </GeometryDrawing.Brush>
+            </GeometryDrawing>
+            <GeometryDrawing Geometry="M 0 4.5 L 8 4.5 L 8 9 L 0 9 Z">
+              <GeometryDrawing.Brush>
+                <LinearGradientBrush StartPoint="0,4.5" EndPoint="0,5">
+                  <GradientStop Offset="0" Color="#00D7A018"/>
+                  <GradientStop Offset="1" Color="#7FD7A018"/>
+                </LinearGradientBrush>
+              </GeometryDrawing.Brush>
+            </GeometryDrawing>
+            <GeometryDrawing Geometry="M 0 9 C 0,5 0,5 2,5 L 5 5 C 5.5,5 6,5 6.5,4.75 L 8 4 L 14 4 C 16,4 16,4 16,6
+                                                    L 16,11 C 16,13 16,13 14,13
+                                                    L 2,13 C 0,13 0,13 0,11 Z">
+              <GeometryDrawing.Brush>
+                <LinearGradientBrush StartPoint="1,6" EndPoint="23,19">
+                  <GradientStop Offset="0" Color="#FFFFE69D"/>
+                  <GradientStop Offset="1" Color="#FFFFC937"/>
+                </LinearGradientBrush>
+              </GeometryDrawing.Brush>
+            </GeometryDrawing>
+            <GeometryDrawing Geometry="M 0 9 C 0,5 0,5 2,5 L 5 5 C 5.5,5 6,5 6.5,4.75 L 8 4 L 14 4
+                                                    L 8 4.25 C 6,5.25 5.5,5.25 5.125,5.25 L 2 5.25 C 0,5.25 0,5.25 0,9.25 z" Brush="#7FFFFFFF"/>
+          </DrawingGroup>
+          <DrawingGroup x:Key="Icon_File">
+            <GeometryDrawing Geometry="M 0 0 L 16 16"/>
+            <GeometryDrawing Geometry="M 2 0 L 10 0 L 14 4 L 14 16 L 2 16 Z" Brush="#FF797774"/>
+            <GeometryDrawing Geometry="M 3 1 L 9.7 1 L 13 4.3 L 13 15 L 3 15 Z" Brush="#FFFAFAFA"/>
+            <GeometryDrawing Geometry="L 9 1 L 9 5 L 14 5 L 14 4 L 10 4 L 10 1 Z" Brush="#FF797774"/>
+          </DrawingGroup>
+          <DrawingGroup x:Key="Icon_Volume">
+            <GeometryDrawing Geometry="M 0 0 L 16 16"/>
+            <GeometryDrawing Geometry="M 4 5 L 12 5 L 14.5 7.5 C 15,8 15,8 15,9 L 1 9 C 1,8 1,8 1.5 7.5 Z" Brush="#FFE1E3E6"/>
+            <GeometryDrawing Geometry="M 12 5 L 14.5 7.5 C 15,8 15,8 15,9 L 10 9 L 10 5 Z">
+              <GeometryDrawing.Brush>
+                <LinearGradientBrush StartPoint="12,5" EndPoint="11.5,5.5">
+                  <GradientStop Offset="0" Color="#FFCDCFD1"/>
+                  <GradientStop Offset="1" Color="#00CDCFD1"/>
+                </LinearGradientBrush>
+              </GeometryDrawing.Brush>
+            </GeometryDrawing>
+            <GeometryDrawing Geometry="M 4 5 L 1.5 7.5 C 1,8 1,8 1,9 L 4 9 L 6 9 L 6 5 Z">
+              <GeometryDrawing.Brush>
+                <LinearGradientBrush StartPoint="4,5" EndPoint="4.5,5.5">
+                  <GradientStop Offset="0" Color="#FFCDCFD1"/>
+                  <GradientStop Offset="1" Color="#00CDCFD1"/>
+                </LinearGradientBrush>
+              </GeometryDrawing.Brush>
+            </GeometryDrawing>
+            <GeometryDrawing Geometry="M 1 9 C 1,8 1,8 2,8 L 14 8
+                                                    C 15,8 15,8 15,9 L 15 11
+                                                    C 15,12 15,12 14,12 L 2 12
+                                                    C 1,12 1,12 1,11 Z">
+              <GeometryDrawing.Brush>
+                <LinearGradientBrush StartPoint="0,8" EndPoint="0,12">
+                  <GradientStop Offset="0" Color="#FF737374"/>
+                  <GradientStop Offset="1" Color="#FFA8A8A8"/>
+                </LinearGradientBrush>
+              </GeometryDrawing.Brush>
+            </GeometryDrawing>
+            <GeometryDrawing Geometry="M 2 9 C 2,8 2,8 3,8 L 13 8
+                                                    C 14,8 14,8 14,9 L 14 10
+                                                    C 14,11 14,11 13,11 L 3 11
+                                                    C 2,11 2,11 2,10 Z">
+              <GeometryDrawing.Brush>
+                <LinearGradientBrush StartPoint="0,8" EndPoint="0,11">
+                  <GradientStop Offset="0" Color="#FF333333"/>
+                  <GradientStop Offset="1" Color="#FF5A5A5A"/>
+                </LinearGradientBrush>
+              </GeometryDrawing.Brush>
+            </GeometryDrawing>
+            <GeometryDrawing>
+              <GeometryDrawing.Geometry>
+                <EllipseGeometry Rect="2.5,8.5,2,2"/>
+              </GeometryDrawing.Geometry>
+              <GeometryDrawing.Brush>
+                <RadialGradientBrush GradientOrigin="3.5,9.5" Center="3.5,9.5">
+                  <GradientStop Offset="0.8" Color="#4001FF01"/>
+                  <GradientStop Offset="1" Color="#0001FF01"/>
+                </RadialGradientBrush>
+              </GeometryDrawing.Brush>
+            </GeometryDrawing>
+            <GeometryDrawing>
+              <GeometryDrawing.Geometry>
+                <EllipseGeometry Rect="3,9,1,1"/>
+              </GeometryDrawing.Geometry>
+              <GeometryDrawing.Brush>
+                <RadialGradientBrush GradientOrigin="3.5,9.5" Center="3.25,9.75">
+                  <GradientStop Offset="0" Color="#FFB6FFB6"/>
+                  <GradientStop Offset="1" Color="#FF01FF01"/>
+                </RadialGradientBrush>
+              </GeometryDrawing.Brush>
+            </GeometryDrawing>
+            <GeometryDrawing Geometry="M 3.23483495705 9.76516504295 A 0.375,0.375 180 1 0 3.76516504295,9.23483495705 A 0.4375,0.4375 135 0 1 3.23483495705,9.76516504295 Z" Brush="#FF00B300"/>
+          </DrawingGroup>
+        </internal:ResourceSelectorConverter>
+      </ResourceDictionary>
+    </ControlTheme.Resources>
+    <Setter Property="Background" Value="{DynamicResource MaterialPaperBrush}"/>
+    <Setter Property="Template"
+            x:DataType="internal:ManagedFileChooserViewModel">
+      <ControlTemplate>
+        <Border Background="{TemplateBinding Background}"
+                BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="{TemplateBinding BorderThickness}"
+                CornerRadius="{TemplateBinding CornerRadius}"
+                Padding="{TemplateBinding Padding}">
+          <DockPanel>
+            <!-- Shortcuts (left panel) -->
+            <ListBox x:Name="PART_QuickLinks" DockPanel.Dock="Left" 
+                     Background="{DynamicResource MaterialCardBackgroundBrush }"
+                     ItemsSource="{Binding QuickLinks}"
+                     SelectedIndex="{Binding QuickLinksSelectedIndex}" Focusable="False"
+                     MaxWidth="200">
+              <ListBox.ItemTemplate>
+                <DataTemplate>
+                  <StackPanel Spacing="4" Orientation="Horizontal" Background="Transparent">
+                    <Image Width="16" Height="16">
+                      <Image.Source>
+                        <DrawingImage Drawing="{Binding IconKey, Converter={StaticResource Icons}}"/>
+                      </Image.Source>
+                    </Image>
+                    <TextBlock Text="{Binding DisplayName}"/>
+                  </StackPanel>
+                </DataTemplate>
+              </ListBox.ItemTemplate>
+            </ListBox>
+            
+            <!-- folder direction path -->
+            <DockPanel x:Name="NavBar" DockPanel.Dock="Top" Margin="8,5,8,0" VerticalAlignment="Center">
+              <Rectangle Fill="{DynamicResource SystemControlHighlightAltBaseMediumLowBrush}" Height="1" Margin="0,5,0,0" DockPanel.Dock="Bottom"/>
+              <DockPanel Margin="4,0">
+                <Button Command="{Binding GoUp}" DockPanel.Dock="Left" Margin="0,0,8,0"
+                        Theme="{StaticResource MaterialFlatButton}">
+                  <Path Data="M 0 7 L 7 0 L 14 7 M 7 0 L 7 16"
+                        Stroke="{CompiledBinding $parent[Button].Foreground}"
+                        StrokeThickness="1" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="0,1,0,-1"/>
+                </Button>
+                <Button Theme="{StaticResource MaterialFlatButton}"
+                        Command="{Binding Refresh}" DockPanel.Dock="Right" Margin="8,0,0,0">
+                  <Path Data="M18.62 3.32c.39 0 .7.29.76.66v3c0 .39-.28.7-.66.76h-3a.77.77 0 0 1-.1-1.52h1.08a7.42 7.42 0 1 0 2.65 4.37.77.77 0 1 1 1.5-.3 8.94 8.94 0 1 1-3-5.12V4.09c0-.43.35-.77.77-.77Z" 
+                        Fill="{CompiledBinding $parent[Button].Foreground}" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="-2,-4,0,0"/>
+                </Button>
+                <TextBox x:Name="Location" Text="{Binding Location}">
+                  <TextBox.KeyBindings>
+                    <KeyBinding Command="{Binding EnterPressed}" Gesture="Enter"/>
+                  </TextBox.KeyBindings>
+                </TextBox>
+              </DockPanel>
+            </DockPanel>
+            
+            <!-- Dialog buttons -->
+            
+            <DockPanel Margin="8,0,8,5" DockPanel.Dock="Bottom">
+              <Rectangle Fill="{DynamicResource MaterialDividerBrush}" Height="1" Margin="0,0,0,5" DockPanel.Dock="Top"/>
+              <DockPanel Margin="4,0">
+                <DockPanel DockPanel.Dock="Top" Margin="0,0,0,4">
+                  <ComboBox DockPanel.Dock="Right"
+                      IsVisible="{Binding ShowFilters}"
+                      ItemsSource="{Binding Filters}"
+                      SelectedItem="{Binding SelectedFilter}" />
+                  <TextBox Text="{Binding FileName}" Watermark="{DynamicResource StringManagedFileChooserFileNameWatermark}" IsVisible="{Binding !SelectingFolder}" />
+                </DockPanel>
+                <CheckBox IsChecked="{Binding ShowHiddenFiles}" Content="{DynamicResource StringManagedFileChooserShowHiddenFilesText}" DockPanel.Dock="Left"/>
+                <UniformGrid x:Name="Finalize" HorizontalAlignment="Right" Rows="1">
+                  <Button Theme="{StaticResource MaterialFlatButton}" Command="{Binding Ok}" MinWidth="80" Content="{DynamicResource StringManagedFileChooserOkText}" />
+                  <Button Theme="{StaticResource MaterialFlatButton}" Command="{Binding Cancel}" MinWidth="80" Content="{DynamicResource StringManagedFileChooserCancelText}" />
+                </UniformGrid>
+              </DockPanel>
+            </DockPanel>
+
+            <!-- Files view -->
+            <DockPanel Grid.IsSharedSizeScope="True">
+              <Grid DockPanel.Dock="Top" Margin="15 5 0 0" HorizontalAlignment="Stretch">
+                <Grid.ColumnDefinitions>
+                  <ColumnDefinition Width="20" SharedSizeGroup="Icon" />
+                  <ColumnDefinition Width="275" SharedSizeGroup="Name" />
+                  <ColumnDefinition Width="16" SharedSizeGroup="Splitter" />
+                  <ColumnDefinition Width="200" SharedSizeGroup="Modified" />
+                  <ColumnDefinition Width="16" SharedSizeGroup="Splitter" />
+                  <ColumnDefinition Width="150" SharedSizeGroup="Type" />
+                  <ColumnDefinition Width="16" SharedSizeGroup="Splitter" />
+                  <ColumnDefinition Width="200" SharedSizeGroup="Size" />
+                  <ColumnDefinition Width="16" SharedSizeGroup="Splitter" />
+                </Grid.ColumnDefinitions>
+                <Grid.Styles>
+                  <Style Selector="GridSplitter">
+                    <Setter Property="Background" Value="{DynamicResource SystemControlHighlightAltBaseMediumLowBrush}"/>
+                    <Setter Property="Template">
+                      <ControlTemplate>
+                        <Border VerticalAlignment="Stretch" BorderThickness="0" Background="#01000000">
+                          <Rectangle Width="1" VerticalAlignment="Stretch" Fill="{TemplateBinding Background}"/>
+                        </Border>
+                      </ControlTemplate>
+                    </Setter>
+                  </Style>
+                </Grid.Styles>
+                <TextBlock Grid.Column="1" Text="{DynamicResource StringManagedFileChooserNameColumn}" />
+                <GridSplitter Grid.Column="2" />
+                <TextBlock Grid.Column="3" Text="{DynamicResource StringManagedFileChooserDateModifiedColumn}" />
+                <GridSplitter Grid.Column="4" />
+                <TextBlock Grid.Column="5" Text="{DynamicResource StringManagedFileChooserTypeColumn}" />
+                <GridSplitter Grid.Column="6" />
+                <TextBlock Grid.Column="7" Text="{DynamicResource StringManagedFileChooserSizeColumn}" />
+                <GridSplitter Grid.Column="8" />
+              </Grid>
+              <ListBox x:Name="PART_Files"
+                  ItemsSource="{Binding Items}"
+                  Margin="0 5"
+                  SelectionMode="{Binding SelectionMode}"
+                  SelectedItems="{Binding SelectedItems}"
+                  Background="Transparent"
+                  ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+                <ListBox.ItemTemplate>
+                  <DataTemplate x:DataType="internal:ManagedFileChooserItemViewModel">
+                    <Grid Background="Transparent">
+                      <Grid.ColumnDefinitions>
+                        <ColumnDefinition SharedSizeGroup="Icon" />
+                        <ColumnDefinition SharedSizeGroup="Name" />
+                        <ColumnDefinition SharedSizeGroup="Splitter" />
+                        <ColumnDefinition SharedSizeGroup="Modified" />
+                        <ColumnDefinition SharedSizeGroup="Splitter" />
+                        <ColumnDefinition SharedSizeGroup="Type" />
+                        <ColumnDefinition SharedSizeGroup="Splitter" />
+                        <ColumnDefinition SharedSizeGroup="Size" />
+                        <ColumnDefinition SharedSizeGroup="Splitter" />
+                      </Grid.ColumnDefinitions>
+                      <Image Width="16" Height="16">
+                        <Image.Source>
+                          <DrawingImage Drawing="{Binding IconKey, Converter={StaticResource Icons}}"/>
+                        </Image.Source>
+                      </Image>
+                      <TextBlock Grid.Column="1" Text="{Binding DisplayName}"/>
+                      <TextBlock Grid.Column="3" Text="{Binding Modified}" />
+                      <TextBlock Grid.Column="5" Text="{Binding Type}" />
+                      <TextBlock Grid.Column="7" HorizontalAlignment="Right">
+                        <TextBlock.Text>
+                          <Binding Path="Size">
+                            <Binding.Converter>
+                              <internal:FileSizeStringConverter/>
+                            </Binding.Converter>
+                          </Binding>
+                        </TextBlock.Text>
+                      </TextBlock>
+                    </Grid>
+                  </DataTemplate>
+                </ListBox.ItemTemplate>
+              </ListBox>
+            </DockPanel>
+          </DockPanel>
+        </Border>
+      </ControlTemplate>
+    </Setter>
+    <Style Selector="^ /template/ ListBox#QuickLinks">
+      <Setter Property="Margin" Value="0"/>
+      <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}"/>
+      <Setter Property="BorderThickness" Value="0"/>
+      <Setter Property="Width" Value="240"/>
+      <Setter Property="Padding" Value="0,20"/>
+      <Setter Property="Template">
+        <ControlTemplate>
+          <Border Name="border" BoxShadow="inset -6 0 3 -3 #20000000" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}">
+            <ScrollViewer Name="PART_ScrollViewer" HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}" VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}">
+              <ItemsPresenter Name="PART_ItemsPresenter"
+                              ItemsPanel="{TemplateBinding ItemsPanel}"
+                              Margin="{TemplateBinding Padding}"/>
+            </ScrollViewer>
+          </Border>
+        </ControlTemplate>
+      </Setter>
+      <Setter Property="ItemContainerTheme">
+        <ControlTheme TargetType="ListBoxItem">
+          <Setter Property="Height" Value="32"/>
+          <Setter Property="Padding" Value="30,6"/>
+          <Setter Property="Template">
+            <ControlTemplate>
+              <Border x:Name="LayoutRoot" CornerRadius="2" Margin="10,0">
+                <Panel>
+                  <Border x:Name="SelectedLine" HorizontalAlignment="Left" Margin="2,6" CornerRadius="0.5" Width="3" Background="{DynamicResource SystemControlHighlightAccentBrush}" IsVisible="{TemplateBinding IsSelected}"/>
+                  <ContentPresenter Name="PART_ContentPresenter"
+                              Background="Transparent"
+                              BorderBrush="Transparent"
+                              BorderThickness="0"
+                              ContentTemplate="{TemplateBinding ContentTemplate}"
+                              Content="{TemplateBinding Content}"
+                              Padding="{TemplateBinding Padding}"
+                              VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                              HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"/>
+
+                </Panel>
+              </Border>
+            </ControlTemplate>
+          </Setter>
+
+          <Style Selector="^:pointerover /template/ Border#LayoutRoot">
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundAltMediumBrush}"/>
+          </Style>
+          <Style Selector="^:selected /template/ Border#LayoutRoot">
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundAltMediumHighBrush}"/>
+          </Style>
+        </ControlTheme>
+      </Setter>
+    </Style>
+
+    <Style Selector="^ /template/ DockPanel#NavBar Button, ^ /template/ DockPanel#NavBar TextBox">
+      <Setter Property="Height" Value="30"/>
+    </Style>
+    <Style Selector="^ /template/ DockPanel#NavBar Button">
+      <Setter Property="VerticalAlignment" Value="Stretch"/>
+      <Setter Property="Width" Value="40"/>
+      <Setter Property="BorderThickness" Value="0"/>
+    </Style>
+    <Style Selector="^ /template/ DockPanel#NavBar Button:not(:pointerover):not(:pressed)">
+      <Setter Property="Background" Value="Transparent"/>
+    </Style>
+
+    <Style Selector="^ /template/ UniformGrid#Finalize > Button">
+      <Setter Property="HorizontalContentAlignment" Value="Center"/>
+      <Setter Property="HorizontalAlignment" Value="Stretch"/>
+      <Setter Property="Margin" Value="4,0,0,0"/>
+    </Style>
+  </ControlTheme>
+  
+  <ControlTheme x:Key="{x:Type dialogs:ManagedFileChooserOverwritePrompt}" TargetType="dialogs:ManagedFileChooserOverwritePrompt">
+    <Setter Property="MinWidth" Value="270" />
+    <Setter Property="MaxWidth" Value="400" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Border Background="{TemplateBinding Background}"
+                BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="{TemplateBinding BorderThickness}"
+                CornerRadius="{TemplateBinding CornerRadius}"
+                Padding="{TemplateBinding Padding}">
+          <StackPanel Spacing="10">
+            <TextBlock TextWrapping="Wrap">
+              <TextBlock.Text>
+                <MultiBinding>
+                  <MultiBinding.Converter>
+                    <converters:StringFormatConverter />
+                  </MultiBinding.Converter>
+                  <DynamicResource ResourceKey="StringManagedFileChooserOverwritePromptFileAlreadyExistsText"/>
+                  <Binding Path ="FileName" RelativeSource="{RelativeSource TemplatedParent}" />
+                </MultiBinding>
+              </TextBlock.Text>
+            </TextBlock>
+            <StackPanel HorizontalAlignment="Right"
+                        Spacing="10"
+                        Orientation="Horizontal">
+              <Button Classes="accent" Content="{DynamicResource StringManagedFileChooserOverwritePromptConfirmText}"
+                      MinWidth="80"
+                      HorizontalContentAlignment="Center"
+                      IsDefault="True"
+                      Command="{Binding Confirm, RelativeSource={RelativeSource TemplatedParent}}" />
+              <Button Content="{DynamicResource StringManagedFileChooserOverwritePromptCancelText}"
+                      MinWidth="80"
+                      IsCancel="True"
+                      HorizontalContentAlignment="Center"
+                      Command="{Binding Cancel, RelativeSource={RelativeSource TemplatedParent}}"  />
+            </StackPanel>
+          </StackPanel>
+        </Border>
+      </ControlTemplate>
+    </Setter>
+  </ControlTheme>
+</ResourceDictionary>

--- a/Material.Styles/Resources/Themes/SplitButton.axaml
+++ b/Material.Styles/Resources/Themes/SplitButton.axaml
@@ -17,7 +17,6 @@
     <Setter Property="CornerRadius" Value="4" />
     <Setter Property="HorizontalContentAlignment" Value="Center" />
     <Setter Property="VerticalContentAlignment" Value="Center" />
-    <Setter Property="Cursor" Value="Hand" />
     <Setter Property="Padding" Value="16 8" />
     <Setter Property="assists:ButtonAssist.HoverColor"
             Value="{Binding $self.Foreground, Converter={StaticResource BrushRoundConverter}}" />
@@ -48,7 +47,7 @@
               <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
 
-            <Button x:Name="PART_PrimaryButton"
+            <Button Name="PART_PrimaryButton"
                     Grid.Column="0"
                     Theme="{StaticResource MaterialSplitButtonComponent}"
                     Content="{TemplateBinding Content}"
@@ -64,10 +63,10 @@
                     Padding="{TemplateBinding Padding}"
                     KeyboardNavigation.IsTabStop="False" />
 
-            <Border x:Name="SeparatorBorder"
+            <Border Name="SeparatorBorder"
                     Grid.Column="1" />
 
-            <Button x:Name="PART_SecondaryButton"
+            <Button Name="PART_SecondaryButton"
                     Grid.Column="2"
                     Theme="{StaticResource MaterialSplitButtonComponent}"
                     CornerRadius="{TemplateBinding CornerRadius, Converter={StaticResource RightCornerRadiusFilterConverter}}"
@@ -87,6 +86,10 @@
       </ControlTemplate>
     </Setter>
     
+    <Style Selector="^:disabled /template/ Button#PART_PrimaryButton">
+      <Setter Property="IsHitTestVisible" Value="False" />
+    </Style>
+    
     <!-- Apply patch to icon of secondary button -->
     <Style Selector="^ /template/ Button#PART_SecondaryButton > Path#ExpandPath">
       <Setter Property="Fill" Value="{TemplateBinding TemplatedControl.Foreground}" />
@@ -96,6 +99,10 @@
     
     <Style Selector="^ /template/ Button#PART_SecondaryButton">
       <Setter Property="Padding" Value="4" />
+    </Style>
+    
+    <Style Selector="^:disabled /template/ Button#PART_SecondaryButton">
+      <Setter Property="IsHitTestVisible" Value="False" />
     </Style>
     
     <!-- popup direction variants -->
@@ -121,25 +128,25 @@
     <!-- Colour variants -->
     
     <Setter Property="Background" Value="{DynamicResource MaterialPrimaryMidBrush}" />
-    <Setter Property="BorderBrush" Value="{DynamicResource MaterialPrimaryMidBrush}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource MaterialPrimaryDarkBrush}" />
     <Setter Property="Foreground" Value="{DynamicResource MaterialPrimaryMidForegroundBrush}" />
     <Setter Property="assists:ShadowAssist.ShadowDepth" Value="Depth1" />
 
     <Style Selector="^.light">
       <Setter Property="Background" Value="{DynamicResource MaterialPrimaryLightBrush}" />
-      <Setter Property="BorderBrush" Value="{DynamicResource MaterialPrimaryLightBrush}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource MaterialPrimaryDarkBrush}" />
       <Setter Property="Foreground" Value="{DynamicResource MaterialPrimaryLightForegroundBrush}" />
     </Style>
 
     <Style Selector="^.dark">
       <Setter Property="Background" Value="{DynamicResource MaterialPrimaryDarkBrush}" />
-      <Setter Property="BorderBrush" Value="{DynamicResource MaterialPrimaryDarkBrush}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource MaterialPaperBrush}" />
       <Setter Property="Foreground" Value="{DynamicResource MaterialPrimaryForegroundBrush}" />
     </Style>
 
     <Style Selector="^.accent">
       <Setter Property="Background" Value="{DynamicResource MaterialSecondaryMidBrush}" />
-      <Setter Property="BorderBrush" Value="{DynamicResource MaterialSecondaryMidBrush}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource MaterialSecondaryDarkBrush}" />
       <Setter Property="Foreground" Value="{DynamicResource MaterialSecondaryMidForegroundBrush}" />
     </Style>
 
@@ -158,6 +165,10 @@
 
     <Style Selector="^:checked:flyout-open /template/ Button">
       <Setter Property="Tag" Value="checked-flyout-open" />
+    </Style>
+    
+    <Style Selector="^:disabled /template/ Border#PART_RootBorder">
+      <Setter Property="Opacity" Value="{StaticResource ButtonDisabledOpacity}" />
     </Style>
   </ControlTheme>
   

--- a/Material.Styles/Resources/Themes/SplitButton.axaml
+++ b/Material.Styles/Resources/Themes/SplitButton.axaml
@@ -1,0 +1,205 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:converters="clr-namespace:Avalonia.Controls.Converters;assembly=Avalonia.Controls"
+                    xmlns:assists="clr-namespace:Material.Styles.Assists">
+  <!-- Add Resources Here -->
+  <converters:CornerRadiusFilterConverter x:Key="TopCornerRadiusFilterConverter" Filter="TopLeft, TopRight" />
+  <converters:CornerRadiusFilterConverter x:Key="RightCornerRadiusFilterConverter" Filter="TopRight, BottomRight" />
+  <converters:CornerRadiusFilterConverter x:Key="BottomCornerRadiusFilterConverter" Filter="BottomLeft, BottomRight" />
+  <converters:CornerRadiusFilterConverter x:Key="LeftCornerRadiusFilterConverter" Filter="TopLeft, BottomLeft" />
+
+  <ControlTheme x:Key="MaterialSplitButtonComponent"
+                BasedOn="{StaticResource MaterialButtonBase}"
+                TargetType="Button">
+  </ControlTheme>
+
+  <ControlTheme x:Key="MaterialSplitButton" TargetType="SplitButton">
+    <Setter Property="CornerRadius" Value="4" />
+    <Setter Property="HorizontalContentAlignment" Value="Center" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="Cursor" Value="Hand" />
+    <Setter Property="Padding" Value="16 8" />
+    <Setter Property="assists:ButtonAssist.HoverColor"
+            Value="{Binding $self.Foreground, Converter={StaticResource BrushRoundConverter}}" />
+    <Setter Property="assists:ButtonAssist.ClickFeedbackColor" Value="{Binding $self.Foreground}" />
+    <Setter Property="FontWeight" Value="Medium" />
+    <Setter Property="FontSize" Value="14" />
+    <Setter Property="BorderThickness" Value="0" />
+    <Setter Property="ClipToBounds" Value="False" />
+    
+    <Setter Property="HorizontalAlignment" Value="Left" />
+    <Setter Property="VerticalAlignment" Value="Center" />
+    <Setter Property="KeyboardNavigation.IsTabStop" Value="True" />
+    <Setter Property="Focusable" Value="True" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Border Name="PART_RootBorder"
+                Background="{TemplateBinding Background}"
+                BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="{TemplateBinding BorderThickness}"
+                CornerRadius="{TemplateBinding CornerRadius}"
+                assists:ShadowAssist.ShadowDepth="{TemplateBinding assists:ShadowAssist.ShadowDepth}">
+          <Border CornerRadius="{TemplateBinding CornerRadius}"
+                  ClipToBounds="True">
+          <Grid Name="PART_RootPanel">
+            <Grid.ColumnDefinitions>
+              <ColumnDefinition Width="*" />
+              <ColumnDefinition Width="Auto" />
+              <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+
+            <Button x:Name="PART_PrimaryButton"
+                    Grid.Column="0"
+                    Theme="{StaticResource MaterialSplitButtonComponent}"
+                    Content="{TemplateBinding Content}"
+                    ContentTemplate="{TemplateBinding ContentTemplate}"
+                    Command="{TemplateBinding Command}"
+                    CommandParameter="{TemplateBinding CommandParameter}"
+                    CornerRadius="{TemplateBinding CornerRadius, Converter={StaticResource LeftCornerRadiusFilterConverter}}"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Stretch"
+                    HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                    VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                    Focusable="False"
+                    Padding="{TemplateBinding Padding}"
+                    KeyboardNavigation.IsTabStop="False" />
+
+            <Border x:Name="SeparatorBorder"
+                    Grid.Column="1" />
+
+            <Button x:Name="PART_SecondaryButton"
+                    Grid.Column="2"
+                    Theme="{StaticResource MaterialSplitButtonComponent}"
+                    CornerRadius="{TemplateBinding CornerRadius, Converter={StaticResource RightCornerRadiusFilterConverter}}"
+                    HorizontalContentAlignment="Center"
+                    VerticalContentAlignment="Center"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Stretch"
+                    Focusable="False"
+                    KeyboardNavigation.IsTabStop="False">
+              <Path Data="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
+                    Width="24" Height="24"
+                    Name="ExpandPath"/>
+            </Button>
+          </Grid>
+          </Border>
+        </Border>
+      </ControlTemplate>
+    </Setter>
+    
+    <!-- Apply patch to icon of secondary button -->
+    <Style Selector="^ /template/ Button#PART_SecondaryButton > Path#ExpandPath">
+      <Setter Property="Fill" Value="{TemplateBinding TemplatedControl.Foreground}" />
+    </Style>
+    
+    <!-- Apply patch to secondary button -->
+    
+    <Style Selector="^ /template/ Button#PART_SecondaryButton">
+      <Setter Property="Padding" Value="4" />
+    </Style>
+    
+    <!-- popup direction variants -->
+    <!-- TODO: make flyout placement changeable by style (not sure yet possible or not) -->
+    
+    <!-- direction to up by default -->
+    <Style Selector="^">
+      <Setter Property="MenuFlyout.Placement" Value="RightEdgeAlignedTop"/>
+      
+      <Style Selector="^ /template/ Button#PART_SecondaryButton > Path#ExpandPath">
+        <Setter Property="RenderTransform" Value="rotate(-90deg)"/>
+      </Style>
+    </Style>
+    
+    <Style Selector="^.down">
+      <Setter Property="MenuFlyout.Placement" Value="RightEdgeAlignedBottom"/>
+      
+      <Style Selector="^ /template/ Button#PART_SecondaryButton > Path#ExpandPath">
+        <Setter Property="RenderTransform" Value="rotate(90deg)"/>
+      </Style>
+    </Style>
+    
+    <!-- Colour variants -->
+    
+    <Setter Property="Background" Value="{DynamicResource MaterialPrimaryMidBrush}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource MaterialPrimaryMidBrush}" />
+    <Setter Property="Foreground" Value="{DynamicResource MaterialPrimaryMidForegroundBrush}" />
+    <Setter Property="assists:ShadowAssist.ShadowDepth" Value="Depth1" />
+
+    <Style Selector="^.light">
+      <Setter Property="Background" Value="{DynamicResource MaterialPrimaryLightBrush}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource MaterialPrimaryLightBrush}" />
+      <Setter Property="Foreground" Value="{DynamicResource MaterialPrimaryLightForegroundBrush}" />
+    </Style>
+
+    <Style Selector="^.dark">
+      <Setter Property="Background" Value="{DynamicResource MaterialPrimaryDarkBrush}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource MaterialPrimaryDarkBrush}" />
+      <Setter Property="Foreground" Value="{DynamicResource MaterialPrimaryForegroundBrush}" />
+    </Style>
+
+    <Style Selector="^.accent">
+      <Setter Property="Background" Value="{DynamicResource MaterialSecondaryMidBrush}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource MaterialSecondaryMidBrush}" />
+      <Setter Property="Foreground" Value="{DynamicResource MaterialSecondaryMidForegroundBrush}" />
+    </Style>
+
+    <Style Selector="^ /template/ Border#SeparatorBorder">
+      <Setter Property="Width" Value="1" />
+      <Setter Property="Background" Value="{TemplateBinding BorderBrush}" />
+    </Style>
+
+    <Style Selector="^:flyout-open /template/ Button">
+      <Setter Property="Tag" Value="flyout-open" />
+    </Style>
+
+    <Style Selector="^:checked /template/ Button">
+      <Setter Property="Tag" Value="checked" />
+    </Style>
+
+    <Style Selector="^:checked:flyout-open /template/ Button">
+      <Setter Property="Tag" Value="checked-flyout-open" />
+    </Style>
+  </ControlTheme>
+  
+  <ControlTheme x:Key="MaterialOutlineSplitButton"
+                BasedOn="{StaticResource MaterialSplitButton}"
+                TargetType="SplitButton">
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="BorderBrush" Value="{DynamicResource MaterialPrimaryMidBrush}" />
+    <Setter Property="Foreground" Value="{DynamicResource MaterialPrimaryMidBrush}" />
+    <Setter Property="Padding" Value="16 6" />
+    <Setter Property="assists:ShadowAssist.ShadowDepth" Value="Depth0" />
+    
+    <!-- Colour variants -->
+
+    <Style Selector="^.accent">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="BorderBrush" Value="{DynamicResource MaterialSecondaryMidBrush}" />
+      <Setter Property="Foreground" Value="{DynamicResource MaterialSecondaryMidBrush}" />
+    </Style>
+
+    <Style Selector="^.light">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="BorderBrush" Value="{DynamicResource MaterialPrimaryLightBrush}" />
+      <Setter Property="Foreground" Value="{DynamicResource MaterialPrimaryLightBrush}" />
+    </Style>
+
+    <Style Selector="^.dark">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="BorderBrush" Value="{DynamicResource MaterialPrimaryDarkBrush}" />
+      <Setter Property="Foreground" Value="{DynamicResource MaterialPrimaryDarkBrush}" />
+    </Style>
+
+
+    <Style Selector="^:disabled">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="BorderBrush" Value="{DynamicResource MaterialBodyBrush}" />
+      <Setter Property="Foreground" Value="{DynamicResource MaterialBodyBrush}" />
+    </Style>
+  </ControlTheme>
+
+  <ControlTheme x:Key="{x:Type SplitButton}"
+                BasedOn="{StaticResource MaterialSplitButton}"
+                TargetType="SplitButton" />
+</ResourceDictionary>


### PR DESCRIPTION
# Details
This PR will add missing control themes that avaloniaUI shipped new controls `SplitButton`, `DropDownButton`, and a dialog theme `ManagedFileChooser` that mentioned in pinned issue #234, and correct `FlyoutPresenter` had no background brush which should have background brush while other themes do that.

# Changes
- Add `SplitButton.axaml` with Raised (default) and Outline variant, usable Themes: `MaterialSplitButton` (default), `MaterialOutlineSplitButton`, both supports `.up` (default) and `.down` classes to change arrow direction, also customise is allowed too by using some tricky style selector to override.
- Add `DropDownButton.axaml` with Raised (default) and Outline variant, usable Themes: `MaterialDropDownButton`  (default), `MaterialOutlineDropDownButton`
- Add `ManagedFileChooser.axaml` from AvaloniaUI Fluent theme with minor correction, redesigning would be required but it exists at least.
- Update Demo buttons and Dialog section with a File Picker API usage (only one yet)
- Add `<Setter Property="Background" Value="{DynamicResource MaterialPaperBrush}" />` to FlyoutPresenter

# Screenshots
![image](https://github.com/user-attachments/assets/23715ce9-54b5-4d69-a6f7-bd25690ff52c)
![image](https://github.com/user-attachments/assets/4140b7b5-b38d-4c46-84b0-b7d1cd3da606)
