### PR TITLE
Introducing Dialog builder API, some minor reworks (second attempt)

### DIFF
--- a/Material.Avalonia.Demo/Material.Avalonia.Demo.csproj
+++ b/Material.Avalonia.Demo/Material.Avalonia.Demo.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Avalonia.Controls.DataGrid" />
+    <PackageReference Include="Avalonia.Controls.ItemsRepeater" />
     <PackageReference Include="Avalonia.Diagnostics" />
     <PackageReference Include="Avalonia.Themes.Simple" />
     <PackageReference Include="Material.Icons.Avalonia" />

--- a/Material.Avalonia.Demo/Pages/DialogDemo.axaml
+++ b/Material.Avalonia.Demo/Pages/DialogDemo.axaml
@@ -14,6 +14,8 @@
         CLOSE
       </Button>
     </StackPanel>
+    
+    <StackPanel x:Key="DialogBuilderElementsPanel" Spacing="8"/>
   </UserControl.Resources>
 
   <StackPanel Margin="16, 0">
@@ -76,6 +78,18 @@
       <StackPanel>
         <TextBlock Classes="Headline6 Subheadline2" Text="Managed file picker" />
         <Button Classes="flat" Content="Example" Click="FilePickerExampleButton_OnClick"/>
+      </StackPanel>
+      
+      <StackPanel>
+        <TextBlock Classes="Headline6 Subheadline2" Text="Dialog builder API (Beta)" />
+        <TextBlock TextWrapping="Wrap" Text="New Material.Dialog API for further use, which have designed to make it able to simple or complex use to create dialog view easily, and also deprecates dialog helper API at same time" />
+        
+        <ToggleSwitch Name="UseDialogHostSwitch"
+                      Content="Use DialogHost"
+                      />
+        <Button Content="Example" Click="DialogBuilderExample1Button_OnClick"/>
+        
+        <TextBlock Name="DialogBuilderResultText" Text=""/>
       </StackPanel>
     </WrapPanel>
   </StackPanel>

--- a/Material.Avalonia.Demo/Pages/DialogDemo.axaml.cs
+++ b/Material.Avalonia.Demo/Pages/DialogDemo.axaml.cs
@@ -1,16 +1,31 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Threading.Tasks;
+using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Templates;
 using Avalonia.Interactivity;
+using Avalonia.LogicalTree;
+using Avalonia.Markup.Xaml.Templates;
+using Avalonia.Media;
 using Avalonia.Platform.Storage;
+using Avalonia.Styling;
 using DialogHostAvalonia;
 using Material.Avalonia.Demo.Models;
 using Material.Avalonia.Demo.ViewModels;
+using Material.Dialog;
+using Material.Dialog.Views;
+using Material.Icons;
+using Material.Icons.Avalonia;
 
 namespace Material.Avalonia.Demo.Pages;
 
 public partial class DialogDemo : UserControl {
+    
+
+    
     public DialogDemo() {
         InitializeComponent();
     }
@@ -36,8 +51,8 @@ public partial class DialogDemo : UserControl {
     }
 
     private async void FilePickerExampleButton_OnClick(object? sender, RoutedEventArgs e) {
-        var toplevel = TopLevel.GetTopLevel(this);
-        var folders = await toplevel!
+
+        var folders = await GetToplevel()
             .StorageProvider
             .OpenFolderPickerAsync(new FolderPickerOpenOptions
         {
@@ -45,4 +60,105 @@ public partial class DialogDemo : UserControl {
             SuggestedFileName = "FileName",
         });
     }
+    
+    private readonly ItemsPanelTemplate _itemsPanelTemplate = new() {
+        Content = new Func<IServiceProvider, object> (_ => new TemplateResult<Control>(new StackPanel { Spacing = 8 }, new NameScope()))
+    };
+    
+    private async void DialogBuilderExample1Button_OnClick(object? sender, RoutedEventArgs e) {
+        
+        var dialogBuilder = new DialogBuilder()
+            .SetTitle("Dialog builder API demo")
+            //.SetTitleIcon(DialogIconKind.Success)
+            .SetTitleIcon(new MaterialIcon {
+                Kind = MaterialIconKind.CogBox,
+                Width = 32,
+                Height = 32
+            })
+            .Text("Appended one line text")
+            .Text("Appended second line text")
+            .PositiveButton("Yay!", "good")
+            .NeutralButton("avaloniaUI is awesome!", "promo")
+            .Control(new Button {
+                Content = "Appended a button"
+            });
+
+        var lorem = new SideSheetData().ImportantInfos;
+
+        for (int i = 0; i < 5; i++) {
+            dialogBuilder.Text(lorem);
+        }
+        
+        dialogBuilder.Style(new Style(a => 
+            a.OfType(typeof(ItemsControl)).Name("PART_ElementHolder"))
+        {
+            Setters = {
+                new Setter(ItemsControl.ItemsPanelProperty, _itemsPanelTemplate)
+            }
+        });
+
+        dialogBuilder.Style(new Style(a => a.OfType(typeof(DialogControlView))) {
+            Setters = {
+                new Setter(MaxWidthProperty, 1200.0)
+            }
+        });
+        
+        await DialogBuilderProcedurePrivate(dialogBuilder);
+    }
+
+    // responsible for common procedure
+    private async Task DialogBuilderProcedurePrivate(DialogBuilder dialogBuilder)
+    {
+        DialogBuilderResultText.Text = "awaiting result..";
+        DialogBuilderResultText.Foreground = Brushes.Violet;
+        var result = await ShowDialogBuilderObjectPrivate(dialogBuilder);
+
+        DialogBuilderResultText.ClearValue(TextBlock.ForegroundProperty);
+        DialogBuilderResultText.Text = result?.ToString() ?? "NULL";
+    }
+
+    // responsible for show dialog builder object via standalone window API or dialog host
+    private async Task<object?> ShowDialogBuilderObjectPrivate(DialogBuilder dialogBuilder)
+    {
+        var useDialogHost = UseDialogHostSwitch.IsChecked ?? false;
+
+        if (useDialogHost) {
+            var dialog = dialogBuilder.Build();
+            
+            // Somehow the dialog would non-closeable, this trick will make it able to close anyway
+            var wrapper = new HeaderedContentControl
+            {
+                Header = new Button {
+                    Command = DialogHost.CloseDialogCommandProperty.Getter.Invoke(
+                        this.FindLogicalAncestorOfType<DialogHost>() ?? throw new InvalidOperationException()),
+                    Content = "Force close"
+                },
+                Content = dialog
+            };
+            
+            return await DialogHost.Show(wrapper, "MainDialogHost");
+        }
+        
+        var window = default(Window);
+        
+        if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime app) {
+            if (app.MainWindow is not MainWindow w)
+                return null;
+
+            window = w;
+        }
+
+        var owner = window ?? throw new InvalidOperationException();
+        var lastState = default(object);
+
+        await foreach (var state in dialogBuilder.BuildAndShowDialogAsync(owner,
+                           modifier: dialog => dialog.AttachDevTools())) {
+            DialogBuilderResultText.Text = state?.ToString();
+            lastState = state;
+        }
+
+        return lastState;
+    }
+
+    private TopLevel GetToplevel() => TopLevel.GetTopLevel(this) ?? throw new InvalidOperationException();
 }

--- a/Material.Avalonia.Demo/Pages/Home.axaml.cs
+++ b/Material.Avalonia.Demo/Pages/Home.axaml.cs
@@ -65,6 +65,13 @@ public partial class Home : UserControl {
 
     public void ShowAboutAvaloniaUI() {
         var window = TopLevel.GetTopLevel(this) as Window;
-        new AboutAvaloniaDialog().ShowDialog(window!);
+
+        // this trick will enforce dialog view refreshing arrange glitch to normal
+        var dialog = new AboutAvaloniaDialog
+        {
+            Width = 0,
+            CanResize = false
+        };
+        dialog.ShowDialog(window!);
     }
 }

--- a/Material.Avalonia.Dialogs/Collections/BlockingConcurrentQueue.cs
+++ b/Material.Avalonia.Dialogs/Collections/BlockingConcurrentQueue.cs
@@ -1,0 +1,31 @@
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Material.Dialog.Collections;
+
+internal class BlockingConcurrentQueue<T>
+{
+    private readonly ConcurrentQueue<T> _queue = new();
+    private readonly SemaphoreSlim _signal = new(0);
+
+    public void Enqueue(T item)
+    {
+        _queue.Enqueue(item);
+        _signal.Release(); // Signal that an item is available
+    }
+
+    public async Task<T> DequeueAsync(CancellationToken cancellationToken = default)
+    {
+        await _signal.WaitAsync(cancellationToken); // Wait until an item is available
+        _queue.TryDequeue(out T item); // Dequeue is guaranteed to succeed after WaitAsync
+        return item;
+    }
+
+    public bool TryDequeue(out T item)
+    {
+        return _queue.TryDequeue(out item);
+    }
+
+    public int Count => _queue.Count;
+}

--- a/Material.Avalonia.Dialogs/Controls/CompositeDataTemplate.cs
+++ b/Material.Avalonia.Dialogs/Controls/CompositeDataTemplate.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Diagnostics;
+using Avalonia.Collections;
+using Avalonia.Controls;
+using Avalonia.Controls.Templates;
+using Avalonia.Data;
+
+namespace Material.Dialog.Controls;
+
+public class CompositeDataTemplate : AvaloniaList<IDataTemplate>, ITreeDataTemplate, IDataTemplate
+{
+    public InstancedBinding? ItemsSelector(object item)
+    {
+        var paramType = item?.GetType();
+        
+        foreach (var t in this)
+        {
+            switch (t)
+            {
+                case ITreeDataTemplate firstStage:
+                    if (firstStage is not ITypedDataTemplate dataTemplate)
+                        throw new ArrayTypeMismatchException($"{item?.GetType() } doesn't have {nameof(ITypedDataTemplate)} interface implementation, which required for recognise the data type and select templates.");
+                    
+                    if(!dataTemplate.DataType?.Equals(paramType) ?? throw new ArgumentNullException())
+                        continue;
+
+                    return firstStage.ItemsSelector(item!);
+            }
+        }
+
+        return null;
+    }
+
+    public Control? Build(object? param)
+    {
+        var paramType = param?.GetType();
+        
+        foreach (var item in this)
+        {
+            switch (item)
+            {
+                case ITypedDataTemplate dataTemplate:
+
+                    var templateType = dataTemplate.DataType ?? throw new ArgumentNullException();
+                    
+                    var isSameType = templateType == paramType;
+                    var isInheritType = paramType?.IsSubclassOf(templateType) ?? false;
+                    
+                    if(!isSameType && !isInheritType)
+                        continue;
+
+                    return dataTemplate.Build(param);
+                
+                default:
+                    throw new NotSupportedException($"{item?.GetType()} is a unsupported type");
+            }
+        }
+
+        Trace.TraceError($"CompositeDataTemplate: No satisfied data template entry for {paramType}.");
+        return null;
+    }
+
+    public bool Match(object? data)
+    {
+        return true;
+    }
+}

--- a/Material.Avalonia.Dialogs/DialogBuilder.cs
+++ b/Material.Avalonia.Dialogs/DialogBuilder.cs
@@ -1,0 +1,303 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Collections;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.LogicalTree;
+using Avalonia.Markup.Xaml.Styling;
+using Avalonia.Media;
+using Avalonia.Media.Imaging;
+using Avalonia.Styling;
+using Material.Dialog.Icons;
+using Material.Dialog.ViewModels;
+using Material.Dialog.ViewModels.Elements;
+using Material.Dialog.ViewModels.Elements.Header;
+using Material.Dialog.ViewModels.Elements.Header.Icons;
+using Material.Dialog.Views;
+using Material.Styles.Controls;
+
+namespace Material.Dialog;
+
+/// <summary>
+/// Dialog builder API, which used to compose dialog elements and build them as a ready-for-use control, or a standalone window.
+/// </summary>
+public class DialogBuilder {
+    private IconViewModelBase? _titleView;
+    private string _titleText = "Warning";
+    private readonly List<object> _elementSet = new();
+    private readonly List<IStyle> _styleSet = new();
+    private readonly List<DialogBuilderButtonViewModel> _positiveButtons = new();
+    private readonly List<DialogBuilderButtonViewModel> _neutralButtons = new();
+    private readonly List<DialogBuilderButtonViewModel> _negativeButtons = new();
+
+    public DialogBuilder SetTitle(string text) {
+        _titleText = text;
+        return this;
+    }
+
+    /// <summary>
+    /// Set title icon with integrated coloured icon (not appending!, you can use custom control if you want do that.)
+    /// </summary>
+    /// <param name="icon">pick one icon that you want to use</param>
+    public DialogBuilder SetTitleIcon(DialogIconKind icon) {
+        _titleView = new DialogIconViewModel {
+            Kind = icon
+        };
+        return this;
+    }
+
+    /// <summary>
+    /// Set title icon with bitmap object.
+    /// </summary>
+    public DialogBuilder SetTitleIcon(Bitmap bitmap, Stretch stretch = Stretch.Uniform) {
+        _titleView = new ImageIconViewModel {
+            Bitmap = bitmap,
+            Stretch = stretch
+        };
+        return this;
+    }
+
+    /// <summary>
+    /// Set title icon with customised user control instance for complex usage.
+    /// </summary>
+    /// <param name="control">non-null control instance</param>
+    public DialogBuilder SetTitleIcon(Control control) {
+        _titleView = new ControlIconViewModel {
+            Control = control
+        };
+        return this;
+    }
+
+    public DialogBuilder Text(string text) {
+        _elementSet.Add(new TextBlockElement {
+            Text = text
+        });
+        return this;
+    }
+
+    /// <summary>
+    /// Append custom control to dialog.
+    /// </summary>
+    /// <param name="control">Valid control</param>
+    public DialogBuilder Control(Control control) {
+        _elementSet.Add(control);
+
+        return this;
+    }
+
+    /// <summary>
+    /// Add a button that close dialog with positive result, also it would take higher priority (sorting)
+    /// </summary>
+    /// <param name="content">text or control</param>
+    /// <param name="returnValue">object that you would want to use as a result</param>
+    /// <param name="shouldClose">you can use this parameter to blocking dialog get closed by some conditions</param>
+    public DialogBuilder PositiveButton(object content, object returnValue, Func<bool>? shouldClose = null) {
+        _positiveButtons.Add(new() {
+            Content = content,
+            ReturnValue = returnValue,
+            ShouldClose = shouldClose
+        });
+
+        return this;
+    }
+
+    /// <summary>
+    /// Add a button that won't close dialog, only providing dialog state.
+    /// </summary>
+    /// <param name="content">text or control</param>
+    /// <param name="returnValue">object that you would want to use as a result</param>
+    public DialogBuilder NeutralButton(object content, object returnValue) {
+        _neutralButtons.Add(new() {
+            Content = content,
+            ReturnValue = returnValue,
+            ShouldClose = () => false
+        });
+
+        return this;
+    }
+
+    /// <summary>
+    /// Add a button that close dialog with negative result, also it would lower priority (sorting)
+    /// </summary>
+    /// <param name="content">text or control</param>
+    /// <param name="returnValue">object that you would want to use as a result</param>
+    /// <param name="shouldClose">you can use this parameter to blocking dialog get closed by some conditions</param>
+    public DialogBuilder NegativeButton(object content, object returnValue, Func<bool>? shouldClose = null) {
+        _negativeButtons.Add(new() {
+            Content = content,
+            ReturnValue = returnValue,
+            ShouldClose = shouldClose
+        });
+
+        return this;
+    }
+
+    public DialogBuilder Style(IStyle style) {
+        _styleSet.Add(style);
+        return this;
+    }
+
+    public Control Build() {
+        return BuildDialogViewPrivate().Item1;
+    }
+    
+    public Tuple<Control, Func<CancellationToken, Task<object>>> BuildWithStateAccessor() {
+
+        var (control, viewModel) = BuildDialogViewPrivate();
+        
+        return new Tuple<Control, Func<CancellationToken, Task<object>>>(control, viewModel.State.DequeueAsync);
+    }
+
+    public Tuple<Control, DialogControlViewModel> BuildDialogViewPrivate() {
+        var viewModel = new DialogControlViewModel {
+            DialogHeader = new DialogHeaderViewModel {
+                Header = _titleText,
+                Icon = _titleView
+            },
+            Views = new AvaloniaList<object>(_elementSet),
+            Answers = new AvaloniaList<DialogBuilderButtonViewModel>(_negativeButtons.Union(_positiveButtons)),
+            AssistantButtons = new AvaloniaList<DialogBuilderButtonViewModel>(_neutralButtons)
+        };
+        var view = new DialogControlView {
+            Content = viewModel
+        };
+
+        view.Styles.AddRange(_styleSet);
+
+        return new Tuple<Control, DialogControlViewModel>(view, viewModel);
+    }
+
+    private const string DialogViewCardName = "PART_DialogViewCard";
+
+    public Window BuildWindow() {
+        return BuildDialogWindowPrivate().Item1;
+    }
+
+    public Tuple<Window, DialogControlViewModel> BuildDialogWindowPrivate() {
+        var dialogView = BuildDialogViewPrivate();
+
+        var view = new Card {
+            Name = DialogViewCardName,
+            Content = dialogView.Item1,
+            CornerRadius = new CornerRadius(8)
+        };
+
+        var window = new Window {
+            Content = view,
+            SizeToContent = SizeToContent.WidthAndHeight,
+            WindowStartupLocation = WindowStartupLocation.CenterOwner,
+            SystemDecorations = SystemDecorations.None,
+            Styles = {
+                new StyleInclude(new Uri("avares://Material.Avalonia.Dialogs/Styles/StyleInclude.axaml")) {
+                    Source = new Uri("avares://Material.Avalonia.Dialogs/Styles/StyleInclude.axaml")
+                }
+            }
+        };
+
+        // Add event handler, remove them once window have been closed.
+        // bind pointer pressed event to allow users drag dialog even without window topbar.
+        view.AddHandler(InputElement.PointerPressedEvent, OnPointerPressedDialogViewPrivate);
+        window.Closing += OnDialogWindowClosingPrivate;
+
+        return new Tuple<Window, DialogControlViewModel>(window, dialogView.Item2);
+    }
+
+
+    /// <summary>
+    /// Build a standalone window, show dialog with constantly receiving dialog state.
+    /// </summary>
+    /// <param name="owner">would be a parent window or any window that should cover before dialog get answered.</param>
+    /// <param name="cancellationToken">cancellation token that used for break state channel loop.</param>
+    /// <param name="modifier">modifier procedure before it shows up.</param>
+    /// <returns>An enumerable state channel that you can receive new dialog state</returns>
+    public async IAsyncEnumerable<object?> BuildAndShowDialogAsync(Window owner,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default, Action<Window>? modifier = null) {
+        var windowInst = BuildDialogWindowPrivate();
+
+        await foreach (var state in ShowDialogPrivateAsync(owner, cancellationToken, modifier, windowInst.Item1,
+                           windowInst.Item2, ShowDialogWindowPrivateAsync!))
+            yield return state;
+    }
+
+    /// <summary>
+    /// Build a standalone window, show as window with constantly receiving dialog state.
+    /// </summary>
+    /// <param name="owner">would be a parent window or any window that should cover before dialog get answered.</param>
+    /// <param name="cancellationToken">cancellation token that used for break state channel loop.</param>
+    /// <param name="modifier">modifier procedure before it shows up.</param>
+    /// <returns>An enumerable state channel that you can receive new dialog state</returns>
+    public async IAsyncEnumerable<object?> BuildAndShowAsync(Window? owner = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default, Action<Window>? modifier = null) {
+        var windowInst = BuildDialogWindowPrivate();
+
+        await foreach (var state in ShowDialogPrivateAsync(owner, cancellationToken, modifier, windowInst.Item1,
+                           windowInst.Item2, ShowWindowPrivateAsync))
+            yield return state;
+    }
+
+    private static async IAsyncEnumerable<object?> ShowDialogPrivateAsync(Window? owner,
+        [EnumeratorCancellation] CancellationToken cancellationToken,
+        Action<Window>? modifier, Window window, DialogControlViewModel vm, Func<Window?, Window, Task> procedure) {
+        modifier?.Invoke(window);
+
+        var cancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+        window.Closed += WindowOnClosed;
+
+        void WindowOnClosed(object sender, EventArgs e) {
+            cancellation.Cancel();
+
+            window.Closed -= WindowOnClosed;
+        }
+
+        var task = procedure(owner, window);
+
+        while (task.Status == TaskStatus.Running && !cancellation.IsCancellationRequested) {
+            yield return await vm.State.DequeueAsync(cancellation.Token);
+        }
+    }
+
+    private static Task ShowDialogWindowPrivateAsync(Window owner, Window window) {
+        var task = window.ShowDialog(owner);
+        return task;
+    }
+
+    private static Task ShowWindowPrivateAsync(Window? owner, Window window) {
+        if (owner != null) {
+            window.Show(owner);
+        }
+        else {
+            window.Show();
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private void OnDialogWindowClosingPrivate(object sender, WindowClosingEventArgs e) {
+        if (sender is not Window window)
+            return;
+
+        var view = (Card)window.GetLogicalDescendants().First(a => {
+            if (a is not Card c)
+                return false;
+
+            return c.Name == DialogViewCardName;
+        });
+
+        window.Closing -= OnDialogWindowClosingPrivate;
+        view.RemoveHandler(InputElement.PointerPressedEvent, OnPointerPressedDialogViewPrivate);
+    }
+
+    private void OnPointerPressedDialogViewPrivate(object sender, PointerPressedEventArgs e) {
+        if (sender is not Control control)
+            return;
+
+        var window = control.FindLogicalAncestorOfType<Window>();
+        window?.BeginMoveDrag(e);
+    }
+}

--- a/Material.Avalonia.Dialogs/DialogBuilder.cs
+++ b/Material.Avalonia.Dialogs/DialogBuilder.cs
@@ -35,6 +35,10 @@ public class DialogBuilder {
     private readonly List<DialogBuilderButtonViewModel> _neutralButtons = new();
     private readonly List<DialogBuilderButtonViewModel> _negativeButtons = new();
 
+    /// <summary>
+    /// Set dialog content title text
+    /// </summary>
+    /// <param name="text">title text</param>
     public DialogBuilder SetTitle(string text) {
         _titleText = text;
         return this;
@@ -73,6 +77,10 @@ public class DialogBuilder {
         return this;
     }
 
+    /// <summary>
+    /// Append supporting text to dialog.
+    /// </summary>
+    /// <param name="text">supporting text</param>
     public DialogBuilder Text(string text) {
         _elementSet.Add(new TextBlockElement {
             Text = text
@@ -137,15 +145,27 @@ public class DialogBuilder {
         return this;
     }
 
+    /// <summary>
+    /// Add custom style to dialog for affecting decoration or visual style of controls or elements of dialog
+    /// </summary>
+    /// <param name="style">valid style instance</param>
     public DialogBuilder Style(IStyle style) {
         _styleSet.Add(style);
         return this;
     }
 
+    /// <summary>
+    /// Build the dialog control with attached parameters.
+    /// </summary>
+    /// <returns>dialog view control instance</returns>
     public Control Build() {
         return BuildDialogViewPrivate().Item1;
     }
     
+    /// <summary>
+    /// Build the dialog control with attached parameters, also you will get an async accessor for access dialog state
+    /// </summary>
+    /// <returns>an dialog control and accessor to get dialog state asynchronously</returns>
     public Tuple<Control, Func<CancellationToken, Task<object>>> BuildWithStateAccessor() {
 
         var (control, viewModel) = BuildDialogViewPrivate();
@@ -174,6 +194,10 @@ public class DialogBuilder {
 
     private const string DialogViewCardName = "PART_DialogViewCard";
 
+    /// <summary>
+    /// Build the standalone dialog window with attached parameters.
+    /// </summary>
+    /// <returns>dialog window instance</returns>
     public Window BuildWindow() {
         return BuildDialogWindowPrivate().Item1;
     }

--- a/Material.Avalonia.Dialogs/DialogBuilder.cs
+++ b/Material.Avalonia.Dialogs/DialogBuilder.cs
@@ -153,7 +153,7 @@ public class DialogBuilder {
         return new Tuple<Control, Func<CancellationToken, Task<object>>>(control, viewModel.State.DequeueAsync);
     }
 
-    public Tuple<Control, DialogControlViewModel> BuildDialogViewPrivate() {
+    private Tuple<Control, DialogControlViewModel> BuildDialogViewPrivate() {
         var viewModel = new DialogControlViewModel {
             DialogHeader = new DialogHeaderViewModel {
                 Header = _titleText,
@@ -178,7 +178,7 @@ public class DialogBuilder {
         return BuildDialogWindowPrivate().Item1;
     }
 
-    public Tuple<Window, DialogControlViewModel> BuildDialogWindowPrivate() {
+    private Tuple<Window, DialogControlViewModel> BuildDialogWindowPrivate() {
         var dialogView = BuildDialogViewPrivate();
 
         var view = new Card {

--- a/Material.Avalonia.Dialogs/Material.Avalonia.Dialogs.csproj
+++ b/Material.Avalonia.Dialogs/Material.Avalonia.Dialogs.csproj
@@ -15,10 +15,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia.Controls.ItemsRepeater"/>
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\Material.Avalonia\Material.Avalonia.csproj"/>
   </ItemGroup>
 

--- a/Material.Avalonia.Dialogs/Resources/TemplateResources.axaml
+++ b/Material.Avalonia.Dialogs/Resources/TemplateResources.axaml
@@ -19,13 +19,21 @@
       <Image Source="{Binding Bitmap}"
              Stretch="{Binding Stretch}" />
     </DataTemplate>
+    
+    <DataTemplate DataType="icons:ControlIconViewModel">
+      <ContentControl Content="{Binding Control}"/>
+    </DataTemplate>
   </controls:CompositeDataTemplate>
 
   <DataTemplate x:Key="DialogButtonTemplate" DataType="elements:DialogButtonViewModel">
-    <!-- ReSharper disable once Xaml.StyleClassNotFound -->
-    <Button Classes="Flat"
-            Content="{Binding Content, FallbackValue='NULL'}"
+    <Button Content="{Binding Content, FallbackValue='NULL'}"
             Command="{Binding Command}"
+            CommandParameter="{Binding }" />
+  </DataTemplate>
+  
+  <DataTemplate x:Key="DialogBuilderButtonTemplate" DataType="elements:DialogBuilderButtonViewModel">
+    <Button Content="{Binding Content, FallbackValue='NULL'}"
+            
             CommandParameter="{Binding }" />
   </DataTemplate>
   
@@ -46,4 +54,17 @@
       </Setter.Value>
     </Setter>
   </ControlTheme>
+  
+  <controls:CompositeDataTemplate x:Key="DialogCommonElementTemplate">
+    <DataTemplate DataType="elements:TextBlockElement">
+      <SelectableTextBlock Name="PART_SupportingText"
+                           Theme="{StaticResource MaterialSelectableTextBlock}"
+                           Classes="Body1"
+                           Text="{Binding Path=Text}"/>         
+    </DataTemplate>
+    
+    <DataTemplate DataType="Control">
+      <ContentControl Content="{Binding}"/>
+    </DataTemplate>
+  </controls:CompositeDataTemplate>
 </ResourceDictionary>

--- a/Material.Avalonia.Dialogs/Resources/TemplateResources.axaml
+++ b/Material.Avalonia.Dialogs/Resources/TemplateResources.axaml
@@ -3,30 +3,47 @@
                     xmlns:elements="clr-namespace:Material.Dialog.ViewModels.Elements"
                     xmlns:icons="clr-namespace:Material.Dialog.ViewModels.Elements.Header.Icons"
                     xmlns:icons1="clr-namespace:Material.Dialog.Icons"
+                    xmlns:controls="clr-namespace:Material.Dialog.Controls"
 
                     x:Class="Material.Dialog.Resources.TemplateResources">
-    <ItemsPanelTemplate x:Key="DialogButtonPlacementPanel">
-        <WrapPanel Orientation="Horizontal"/>
-    </ItemsPanelTemplate>
-    
-    <RecyclingElementFactory x:Key="DialogHeaderIconTemplate" SelectTemplateKey="DialogHeaderIconTemplate_OnSelectTemplateKey">
-        <RecyclingElementFactory.Templates>
-            <DataTemplate DataType="icons:DialogIconViewModel" x:Key="DialogIcon">
-                <icons1:DialogIcon Kind="{Binding Kind}"/>
-            </DataTemplate>
-            
-            <DataTemplate DataType="icons:ImageIconViewModel" x:Key="DialogImageIcon">
-                <Image Source="{Binding Bitmap}"
-                       Stretch="{Binding Stretch}"/>
-            </DataTemplate>
-        </RecyclingElementFactory.Templates>
-    </RecyclingElementFactory>
-    
-    <DataTemplate x:Key="DialogButtonTemplate" DataType="elements:DialogButtonViewModel">
-        <!-- ReSharper disable once Xaml.StyleClassNotFound -->
-        <Button Classes="Flat"
-                Content="{Binding Content, FallbackValue='NULL'}"
-                Command="{Binding Command}"
-                CommandParameter="{Binding }"/>
+  <ItemsPanelTemplate x:Key="DialogButtonPlacementPanel">
+    <WrapPanel Orientation="Horizontal" />
+  </ItemsPanelTemplate>
+  
+  <controls:CompositeDataTemplate x:Key="DialogHeaderIconTemplate">
+    <DataTemplate DataType="icons:DialogIconViewModel">
+      <icons1:DialogIcon Kind="{Binding Kind}" />
     </DataTemplate>
+    
+    <DataTemplate DataType="icons:ImageIconViewModel">
+      <Image Source="{Binding Bitmap}"
+             Stretch="{Binding Stretch}" />
+    </DataTemplate>
+  </controls:CompositeDataTemplate>
+
+  <DataTemplate x:Key="DialogButtonTemplate" DataType="elements:DialogButtonViewModel">
+    <!-- ReSharper disable once Xaml.StyleClassNotFound -->
+    <Button Classes="Flat"
+            Content="{Binding Content, FallbackValue='NULL'}"
+            Command="{Binding Command}"
+            CommandParameter="{Binding }" />
+  </DataTemplate>
+  
+  <ControlTheme x:Key="{x:Type icons1:DialogIcon}"
+                TargetType="icons1:DialogIcon">
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate>
+          <Viewbox Stretch="Uniform"
+                   ClipToBounds="False"
+                   HorizontalAlignment="Stretch"
+                   VerticalAlignment="Stretch">
+            <Path Name="PATH_DialogIconVectorPath"
+                  Data="{TemplateBinding Data}"
+                  Fill="{TemplateBinding Foreground}" />
+          </Viewbox>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </ControlTheme>
 </ResourceDictionary>

--- a/Material.Avalonia.Dialogs/Resources/TemplateResources.axaml.cs
+++ b/Material.Avalonia.Dialogs/Resources/TemplateResources.axaml.cs
@@ -1,34 +1,10 @@
-﻿using System;
-using Avalonia.Controls;
-using Material.Dialog.ViewModels.Elements;
-using Material.Dialog.ViewModels.Elements.Header.Icons;
+﻿using Avalonia.Controls;
 
 namespace Material.Dialog.Resources
 {
     // ReSharper disable once UnusedType.Global
     public class TemplateResources : ResourceDictionary
     {
-        // ReSharper disable UnusedMember.Local
-        private void DialogButtonTemplate_OnSelectTemplateKey(object _, SelectTemplateEventArgs e)
-        {
-            e.TemplateKey = e.DataContext switch
-            {
-                ObsoleteDialogButtonViewModel _ => "ObsoleteButton",
-                DialogButtonViewModel _ => "StandardButton",
-                _ => throw new ArgumentOutOfRangeException()
-            };
-        }
 
-        private void DialogHeaderIconTemplate_OnSelectTemplateKey(object sender, SelectTemplateEventArgs e)
-        {
-            e.TemplateKey = e.DataContext switch
-            {
-                DialogIconViewModel _ => "DialogIcon",
-                ImageIconViewModel _ => "DialogImageIcon",
-                _ => throw new ArgumentOutOfRangeException()
-            };
-        }
-
-        // ReSharper restore UnusedMember.Local
     }
 }

--- a/Material.Avalonia.Dialogs/Styles/DialogHeader.axaml
+++ b/Material.Avalonia.Dialogs/Styles/DialogHeader.axaml
@@ -1,0 +1,25 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:header="clr-namespace:Material.Dialog.ViewModels.Elements.Header">
+  <!-- Add Resources Here -->
+  <DataTemplate DataType="header:DialogHeaderViewModel"
+                x:Key="MaterialDialogHeaderTemplate">
+    <DockPanel Name="PART_HeaderPanel">
+      <ContentControl Name="PART_HeaderIcon"
+                      Content="{Binding Icon}"
+                      ContentTemplate="{StaticResource DialogHeaderIconTemplate}"
+                      IsVisible="{Binding Icon, Converter={x:Static ObjectConverters.IsNotNull}}" />
+      
+      <DockPanel.IsVisible>
+        <MultiBinding Converter="{x:Static BoolConverters.Or}">
+          <CompiledBinding Converter="{x:Static ObjectConverters.IsNotNull}" Path="Icon" />
+          <CompiledBinding Converter="{x:Static StringConverters.IsNotNullOrEmpty}" Path="Header" />
+        </MultiBinding>
+      </DockPanel.IsVisible>
+      <SelectableTextBlock Name="PART_HeaderText"
+                 Classes="Headline6"
+                 IsVisible="{Binding Header, Converter={x:Static ObjectConverters.IsNotNull}}"
+                 Text="{Binding Header, FallbackValue='DIALOG_HEADER_NULL'}" />
+    </DockPanel>
+  </DataTemplate>
+</ResourceDictionary>

--- a/Material.Avalonia.Dialogs/Styles/StyleInclude.axaml
+++ b/Material.Avalonia.Dialogs/Styles/StyleInclude.axaml
@@ -1,7 +1,8 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:assists="clr-namespace:Material.Styles.Assists;assembly=Material.Styles"
-        xmlns:controls="clr-namespace:Material.Dialog.Controls" >
+        xmlns:controls="clr-namespace:Material.Dialog.Controls"
+        xmlns:views="clr-namespace:Material.Dialog.Views">
     <Style Selector="Window">
         <Setter Property="CanResize" Value="False"/>
         <Setter Property="SizeToContent" Value="WidthAndHeight"/>
@@ -11,6 +12,7 @@
     <Style Selector="Window[SystemDecorations=None]">
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="TransparencyLevelHint" Value="Transparent" />
+        <Setter Property="Padding" Value="32"/>
     </Style>
     
     <Style Selector="Window[SystemDecorations=Full] controls|EmbeddedDialogControl /template/
@@ -19,5 +21,12 @@
         <Setter Property="CornerRadius" Value="0"/>
         <Setter Property="Margin" Value="0"/>
     </Style>
+  
+  <Style Selector="Window[SystemDecorations=Full] views|DialogControlView /template/
+                     Border#PART_RootBorder">
+    <Setter Property="assists:ShadowAssist.ShadowDepth" Value="Depth0"/>
+    <Setter Property="CornerRadius" Value="0"/>
+    <Setter Property="Margin" Value="0"/>
+  </Style>
     
 </Styles>

--- a/Material.Avalonia.Dialogs/ViewModels/CustomDialogViewModel.cs
+++ b/Material.Avalonia.Dialogs/ViewModels/CustomDialogViewModel.cs
@@ -29,7 +29,7 @@ namespace Material.Dialog.ViewModels
             }
         }
 
-        public CustomDialogViewModel(CustomDialog dialog) : base(dialog)
+        public CustomDialogViewModel(CustomDialog? dialog) : base(dialog)
         {
         }
     }

--- a/Material.Avalonia.Dialogs/ViewModels/DialogControlViewModel.cs
+++ b/Material.Avalonia.Dialogs/ViewModels/DialogControlViewModel.cs
@@ -1,0 +1,18 @@
+using Avalonia.Collections;
+using Material.Dialog.Collections;
+using Material.Dialog.ViewModels.Elements;
+using Material.Dialog.ViewModels.Elements.Header;
+
+namespace Material.Dialog.ViewModels;
+
+public class DialogControlViewModel : DialogViewModelBase {
+    public DialogHeaderViewModel? DialogHeader { get; set; }
+
+    public AvaloniaList<object> Views { get; set; } = [];
+
+    internal BlockingConcurrentQueue<object> State { get; } = new();
+
+    public AvaloniaList<DialogBuilderButtonViewModel>? Answers { get; set; }
+
+    public AvaloniaList<DialogBuilderButtonViewModel>? AssistantButtons { get; set; }
+}

--- a/Material.Avalonia.Dialogs/ViewModels/DialogWindowViewModel.cs
+++ b/Material.Avalonia.Dialogs/ViewModels/DialogWindowViewModel.cs
@@ -9,14 +9,14 @@ namespace Material.Dialog.ViewModels
 {
     public abstract class DialogWindowViewModel : DialogViewModelBase
     {
-        public DialogWindowViewModel(Window window)
+        public DialogWindowViewModel(Window? window)
         {
             Window = window;
         }
 
-        private Window _window;
+        private Window? _window;
 
-        protected Window Window
+        protected Window? Window
         {
             get => _window;
             private set => _window = value;

--- a/Material.Avalonia.Dialogs/ViewModels/Elements/DialogBuilderButtonViewModel.cs
+++ b/Material.Avalonia.Dialogs/ViewModels/Elements/DialogBuilderButtonViewModel.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Material.Dialog.ViewModels.Elements;
+
+public class DialogBuilderButtonViewModel : DialogViewModelBase {
+    public object? Content { get; set; }
+    public object ReturnValue { get; set; }
+    public Func<bool>? ShouldClose { get; set; }
+}

--- a/Material.Avalonia.Dialogs/ViewModels/Elements/Header/DialogHeaderViewModel.cs
+++ b/Material.Avalonia.Dialogs/ViewModels/Elements/Header/DialogHeaderViewModel.cs
@@ -1,0 +1,24 @@
+using Material.Dialog.ViewModels.Elements.Header.Icons;
+
+namespace Material.Dialog.ViewModels.Elements.Header;
+
+public class DialogHeaderViewModel : DialogViewModelBase {
+    public IconViewModelBase? Icon {
+        get => _icon;
+        set {
+            _icon = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public object? Header {
+        get => _header;
+        set {
+            _header = value;
+            OnPropertyChanged();
+        }
+    }
+
+    private IconViewModelBase? _icon;
+    private object? _header;
+}

--- a/Material.Avalonia.Dialogs/ViewModels/Elements/Header/Icons/ControlIconViewModel.cs
+++ b/Material.Avalonia.Dialogs/ViewModels/Elements/Header/Icons/ControlIconViewModel.cs
@@ -1,0 +1,7 @@
+using Avalonia.Controls;
+
+namespace Material.Dialog.ViewModels.Elements.Header.Icons;
+
+public class ControlIconViewModel : IconViewModelBase {
+    public Control Control { get; set; }
+}

--- a/Material.Avalonia.Dialogs/ViewModels/Elements/TextBlockElement.cs
+++ b/Material.Avalonia.Dialogs/ViewModels/Elements/TextBlockElement.cs
@@ -1,0 +1,14 @@
+namespace Material.Dialog.ViewModels.Elements;
+
+public class TextBlockElement : DialogViewModelBase {
+
+    private string _text = string.Empty;
+    public string Text
+    {
+        get => _text;
+        set {
+            _text = value;
+            OnPropertyChanged();
+        }
+    }
+}

--- a/Material.Avalonia.Dialogs/Views/DialogControlView.axaml
+++ b/Material.Avalonia.Dialogs/Views/DialogControlView.axaml
@@ -1,0 +1,133 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:viewModels="clr-namespace:Material.Dialog.ViewModels"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="Material.Dialog.Views.DialogControlView">
+  <UserControl.Resources>
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <ResourceInclude Source="avares://Material.Avalonia.Dialogs/Resources/TemplateResources.axaml" />
+        <ResourceInclude Source="avares://Material.Avalonia.Dialogs/Styles/DialogHeader.axaml" />
+      </ResourceDictionary.MergedDictionaries>
+    </ResourceDictionary>
+  </UserControl.Resources>
+
+  <UserControl.ContentTemplate>
+    <DataTemplate DataType="viewModels:DialogControlViewModel">
+      <Grid RowDefinitions="Auto, *, Auto">
+        <ContentControl Grid.Row="0" Name="PART_HeaderControl"
+                        ContentTemplate="{StaticResource MaterialDialogHeaderTemplate}"
+                        Content="{Binding DialogHeader}" />
+        
+        <ScrollViewer Grid.Row="1" Name="PART_ContentViewer">
+          <ItemsControl Name="PART_ElementHolder"
+                        ItemsSource="{Binding Views}"
+                        ItemTemplate="{StaticResource DialogCommonElementTemplate}">
+            
+          </ItemsControl>
+        </ScrollViewer>
+        
+        <DockPanel Grid.Row="2" Name="PART_ButtonsPanel">
+
+          <ItemsControl Name="PART_NeutralButtonPlacement"
+                        ItemsSource="{Binding AssistantButtons}"
+                        ItemTemplate="{StaticResource DialogBuilderButtonTemplate}"
+                        ItemsPanel="{StaticResource DialogButtonPlacementPanel}" />
+
+          <ItemsControl Name="PART_ButtonPlacement"
+                        ItemsSource="{Binding Answers}"
+                        ItemTemplate="{StaticResource DialogBuilderButtonTemplate}"
+                        ItemsPanel="{StaticResource DialogButtonPlacementPanel}" />
+        </DockPanel>
+      </Grid>
+    </DataTemplate>
+  </UserControl.ContentTemplate>
+
+  <UserControl.Styles>
+    <Style Selector="ContentControl#PART_HeaderControl">
+      <Style Selector="^ > DockPanel#PART_HeaderPanel">
+        <Setter Property="Margin" Value="24,24,24,14" />
+        <Setter Property="Dock" Value="Top" />
+        
+        <Style Selector="^ > ContentControl#PART_HeaderIcon">
+          <Setter Property="Width" Value="32" />
+          <Setter Property="Height" Value="32" />
+          <Setter Property="Margin" Value="0,0,8,0" />
+        </Style>
+        
+        <Style Selector="^ > SelectableTextBlock#PART_HeaderText">
+          <Setter Property="VerticalAlignment" Value="Center" />
+        </Style>
+      </Style>
+    </Style>
+    
+    <Style Selector="ItemsControl#PART_ElementHolder">
+      <Setter Property="Margin" Value="0,0,0,16"/>
+      
+      <Style Selector="^ SelectableTextBlock#PART_SupportingText">
+        <Setter Property="Margin" Value="24, 0"/>
+        <Setter Property="TextWrapping" Value="Wrap"/>
+      </Style>
+    </Style>
+    
+    <Style Selector="DockPanel#PART_ButtonsPanel">
+      <Style Selector="^ > ItemsControl#PART_NeutralButtonPlacement">
+        <Setter Property="DockPanel.Dock" Value="Left"/>
+        <Setter Property="HorizontalAlignment" Value="Left"/>
+      </Style>
+      
+      <Style Selector="^ > ItemsControl#PART_ButtonPlacement">
+        <Setter Property="DockPanel.Dock" Value="Right"/>
+        <Setter Property="HorizontalAlignment" Value="Right"/>
+      </Style>
+      
+      <Style Selector="^ > ItemsControl Button">
+        <!-- ReSharper disable once Xaml.StaticResourceNotResolved -->
+        <Setter Property="Theme" Value="{StaticResource MaterialFlatButton}"/>
+      </Style>
+    </Style>
+
+    <!--
+    <Style Selector="controls|EmbeddedDialogControl /template/ DockPanel#PART_ButtonsPanel">
+      <Setter Property="Margin" Value="4,16,4,4" />
+      <Setter Property="Dock" Value="Bottom" />
+    </Style>
+
+    <Style Selector="controls|EmbeddedDialogControl /template/ ItemsControl#PART_ButtonPlacement">
+      <Setter Property="HorizontalAlignment" Value="Right" />
+    </Style>
+
+    <Style Selector="controls|EmbeddedDialogControl /template/ ItemsControl#PART_ButtonPlacement Button,
+                           controls|EmbeddedDialogControl /template/ ItemsControl#PART_NeutralButtonPlacement Button">
+      <Setter Property="Margin" Value="4" />
+    </Style>
+
+    <Style Selector="controls|EmbeddedDialogControl /template/ ItemsControl#PART_NeutralButtonPlacement ItemsPresenter">
+      <Setter Property="(KeyboardNavigation.TabNavigation)" Value="Continue" />
+    </Style>
+
+    <Style Selector="controls|EmbeddedDialogControl /template/ ItemsControl#PART_ButtonPlacement ItemsPresenter">
+      <Setter Property="(KeyboardNavigation.TabNavigation)" Value="Continue" />
+    </Style>
+
+
+    <Style Selector="controls|EmbeddedDialogControl > ScrollViewer#PART_ScrollViewer > StackPanel#PART_ContentPanel > TextBlock#PART_SupportingText">
+      <Setter Property="Margin" Value="24,0" />
+      <Setter Property="TextWrapping" Value="Wrap" />
+    </Style>
+
+    ~1~ For TextField dialog @1@
+    <Style Selector="controls|EmbeddedDialogControl > ScrollViewer#PART_ScrollViewer > StackPanel#PART_ContentPanel > ItemsControl#PART_TextFields">
+      <Setter Property="Margin" Value="24,4" />
+      <Setter Property="HorizontalAlignment" Value="Stretch" />
+    </Style>
+
+    ~1~ Origin contribution by dojo90
+               https://github.com/AvaloniaCommunity/Material.Avalonia/pull/147 @1@
+    <Style Selector="controls|EmbeddedDialogControl > ScrollViewer#PART_ScrollViewer > StackPanel#PART_ContentPanel > ItemsControl#PART_TextFields ItemsPresenter">
+      <Setter Property="(KeyboardNavigation.TabNavigation)" Value="Continue" />
+    </Style>-->
+  </UserControl.Styles>
+</UserControl>

--- a/Material.Avalonia.Dialogs/Views/DialogControlView.axaml.cs
+++ b/Material.Avalonia.Dialogs/Views/DialogControlView.axaml.cs
@@ -1,0 +1,9 @@
+using Avalonia.Controls;
+
+namespace Material.Dialog.Views;
+
+public partial class DialogControlView : UserControl {
+    public DialogControlView() {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
# WIP
> [!WARNING]  
> This PR might bring some breaking changes, because this implementation would better than `DialogHelper` and it will replace dialog creation procedure in `DialogHelper` and thus will break your current styles modifications. Also the API definitions is pretty sketchy and raw, we need some more conversations to improve it to make it works best.

# Details
This PR will add Dialog builder API, which allows you to create dialog control / window easily and flexible to put elements freely, and no more limited for standalone window use. You can use dialog layout whatever you want. ~~Also, I noticed that there have missing control theme for `HeaderedContentControl`, and I have added my control theme implementation for it.~~ its in PR #457 

# Exposed API
> [!WARNING]  
> Those API is pretty sketchy, some of them would be questionable for further use. Please leave comments for trending about them!

- `DialogBuilder`
  - `SetTitle(string text)`
  > Set dialog content title text
  - `SetTitleIcon(DialogIconKind icon)`
  > Set title icon with integrated coloured icon (not appending!, you can use custom control if you want do that.)
  - `SetTitleIcon(Bitmap bitmap, Stretch stretch = Stretch.Uniform)`
  > Set title icon with bitmap object.
  - `Text(string text)`
  > Append supporting text to dialog.
  - `Control(Control control)`
  > Append custom control to dialog.
  - `PositiveButton(object content, object returnValue, Func<bool>? shouldClose = null)`
  > Add a button that close dialog with positive result, also it would take higher priority (sorting)
  - `NeutralButton(object content, object returnValue, Action? onClick = null)`
  > Add a button that won't close dialog, only providing dialog state.
  - `NegativeButton(object content, object returnValue, Func<bool>? shouldClose = null)`
  > Add a button that close dialog with negative result, also it would lower priority (sorting)
  - `Style(IStyle style)`
  > Add custom style to dialog for affecting decoration or visual style of controls or elements of dialog
  - `Build()`
  > Build the dialog control with attached parameters.
  - `BuildWithStateAccessor()`
  > Build the dialog control with attached parameters, also you will get an async accessor for access dialog state 
  - `BuildWindow()`
  > Build the standalone dialog window with attached parameters.
  - `BuildAndShowDialogAsync(Window owner, CancellationToken cancellationToken = default, Action<Window>? modifier = null)`
  > Build a standalone window, show dialog with constantly receiving dialog state.
  - `BuildAndShowAsync(Window? owner = null, CancellationToken cancellationToken = default, Action<Window>? modifier = null)`
  > Build a standalone window, show as window with constantly receiving dialog state.

# Changes
- Moving Avalonia.Controls.ItemsRepeater usage to Demo instead. Material.Dialog package will no more use it since I have added `CompositeDataTemplate` that works more easily to pick a suitable `DataTemplate` from a set.
- Fix: about avaloniaUI dialog layout brokened. It was avaloniaUI issue but I have found a workaround for it. I'm not that good to submit such fix to their repository so I'll leave it here.
- ~~Add: ControlTheme for `HeaderedContentControl`~~ PR #457 

# Screenshots
![image](https://github.com/user-attachments/assets/3e3de757-7046-4cab-96b6-71aa636c79d6)
![image](https://github.com/user-attachments/assets/ca7c58c5-7a95-4b49-9a71-792313efca0b)
