### PR TITLE
Improved Ripple visual effect

### DIFF
--- a/Material.Ripple/RippleEffect.cs
+++ b/Material.Ripple/RippleEffect.cs
@@ -168,6 +168,7 @@ namespace Material.Ripple {
                 RippleFill.ToImmutable(),
                 Ripple.Easing,
                 Ripple.Duration,
+                TimeSpan.FromSeconds(FadeOutDuration),
                 RippleOpacity,
                 CornerRadius,
                 x, y, w, h, t);
@@ -218,6 +219,14 @@ namespace Material.Ripple {
         public bool UseTransitions {
             get => GetValue(UseTransitionsProperty);
             set => SetValue(UseTransitionsProperty, value);
+        }
+        
+        public static readonly StyledProperty<double> FadeOutDurationProperty =
+            AvaloniaProperty.Register<RippleEffect, double>(nameof(FadeOutDuration), defaultValue: 0.450, validate: v => v > 0.0);
+
+        public double FadeOutDuration {
+            get => GetValue(FadeOutDurationProperty);
+            set => SetValue(FadeOutDurationProperty, value);
         }
 
         #endregion Styled properties

--- a/Material.Ripple/RippleHandler.cs
+++ b/Material.Ripple/RippleHandler.cs
@@ -65,6 +65,9 @@ internal class RippleHandler : CompositionCustomVisualHandler {
             }
         } else {
             currentRadius = _maxRadius;
+
+            if (_secondStepStart != null)
+                currentOpacity = 0.0;
         }
 
         using (drawingContext.PushClip(_cornerRadiusRect)) {
@@ -98,11 +101,12 @@ internal class RippleHandler : CompositionCustomVisualHandler {
     }
 
     public override void OnAnimationFrameUpdate() {
-        // Continue animation until the total duration has elapsed
-        if (_animationElapsed >= _duration && !_secondStepStart.HasValue) 
-            return;
-
-        TriggerNextFrameUpdatePrivate();
+        // Continue animation until the expansion duration has elapsed OR the fade-out is complete
+        if ((!_secondStepStart.HasValue && _animationElapsed < _duration) ||
+            (_secondStepStart.HasValue && _animationElapsed < _secondStepStart + _fadeOutDuration))
+        {
+            TriggerNextFrameUpdatePrivate();
+        }
     }
 
     private void TriggerNextFrameUpdatePrivate()

--- a/Material.Ripple/RippleHandler.cs
+++ b/Material.Ripple/RippleHandler.cs
@@ -21,10 +21,12 @@ internal class RippleHandler : CompositionCustomVisualHandler {
     private TimeSpan _animationElapsed;
     private TimeSpan? _lastServerTime;
     private TimeSpan? _secondStepStart;
+    private readonly TimeSpan _fadeOutDuration;
 
     public RippleHandler(IImmutableBrush brush,
         Easing easing,
         TimeSpan duration,
+        TimeSpan fadeOutDuration,
         double opacity,
         CornerRadius cornerRadius,
         double positionX, double positionY,
@@ -40,6 +42,7 @@ internal class RippleHandler : CompositionCustomVisualHandler {
         _center = new Point(positionX, positionY);
 
         _maxRadius = Math.Sqrt(Math.Pow(outerWidth, 2) + Math.Pow(outerHeight, 2));
+        _fadeOutDuration = fadeOutDuration;
     }
 
     public override void OnRender(ImmediateDrawingContext drawingContext) {
@@ -57,7 +60,7 @@ internal class RippleHandler : CompositionCustomVisualHandler {
             // Fade-out starts when the second message is received
             if (_secondStepStart is { } secondStepStart) {
                 var timeSinceSecondStep = _animationElapsed - secondStepStart;
-                var fadeOutProgress = Math.Clamp((double)timeSinceSecondStep.Ticks / TimeSpan.FromSeconds(1).Ticks, 0, 1);
+                var fadeOutProgress = Math.Clamp((double)timeSinceSecondStep.Ticks / _fadeOutDuration.Ticks, 0, 1);
                 currentOpacity = _opacity * (1.0 - _easing.Ease(fadeOutProgress));
             }
         } else {


### PR DESCRIPTION
# Details
This PR will correct some `RippleHandler` renderer abnormal behaviours, which may happens some graphical issues while effects is working, also adding `FadeOutDuration` property to allow users to control how long it take to fade out.

# Exposed API
- `RippleEffect.FadeOutDuration` duration for second state (fade-out)

# Changes
- Rewrote procedure and algorithm in `RippleHandler`, thanks again to @maxkatz6 for converting this effect to custom renderer handler way.

# Known issues:
- `RippleEffect.FadeOutDuration` should not higher than `Ripple.Duration`, otherwise Ripple effect will be deleted early.

# Screenshots
![e83jh908dfh3489ty43897ty3489rh438](https://github.com/user-attachments/assets/260547d9-339c-4e44-a862-bdaaaed67f1e)
