### PR TITLE
Added Combobox dense class to be consistent with TextBox dense class

### DIFF
--- a/Material.Avalonia.Demo/Pages/ComboBoxesDemo.axaml
+++ b/Material.Avalonia.Demo/Pages/ComboBoxesDemo.axaml
@@ -51,6 +51,15 @@
               <TextBlock Text="Item 4" />
             </ComboBox>
           </showMeTheXaml:XamlDisplay>
+          <showMeTheXaml:XamlDisplay UniqueId="ComboBoxesDense">
+            <ComboBox Theme="{StaticResource MaterialOutlineComboBox}" assist:ComboBoxAssist.Label="ComboBoxDense"
+                      Classes="dense">
+              <TextBlock Text="Item 1" />
+              <TextBlock Text="Item 2" />
+              <TextBlock Text="Item 3" />
+              <TextBlock Text="Item 4" />
+            </ComboBox>
+          </showMeTheXaml:XamlDisplay>
 
           <showMeTheXaml:XamlDisplay UniqueId="ComboBoxesError">
             <ComboBox PlaceholderText="Select a Item">

--- a/Material.Styles/Converters/RectHollowClipConverter.cs
+++ b/Material.Styles/Converters/RectHollowClipConverter.cs
@@ -13,7 +13,7 @@ namespace Material.Styles.Converters {
     /// </summary>
     public class RectHollowClipConverter : IMultiValueConverter {
         public object Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture) {
-            double hOffset = 4, vOffset = -8;
+            double hOffset = 4, vOffset = -4; // vOffset -8 was limiting ComboBox Outline (dense style) floating label by cutting in border when not present in border §not focused and nothing selected. See 
             var t = new Thickness(2);
 
             if (parameter is RectHollowClipParameter param) {

--- a/Material.Styles/Resources/Themes/ComboBox.axaml
+++ b/Material.Styles/Resources/Themes/ComboBox.axaml
@@ -413,7 +413,22 @@
       <Setter Property="BorderThickness" Value="2" />
       <Style Selector="^ /template/ TextBlock#floatingWatermark">
         <Setter Property="Foreground" Value="{DynamicResource MaterialPrimaryMidBrush}"/>
-      </Style> 
+      </Style>
     </Style>
+
+    <!-- Dense overrides -->
+    <Style Selector="^.dense">
+      <Setter Property="Padding" Value="10,2" />
+    </Style>
+    <Style Selector="^.dense /template/ Grid#PART_RootBorder">
+      <Setter Property="MinHeight" Value="36" />
+    </Style>
+    <Style Selector="^.dense[SelectedIndex=-1]:not(:focus-within) /template/ Border#watermarkRoot">
+      <Setter Property="Margin" Value="6,8,6,0" />
+    </Style>
+    <Style Selector="^.dense:focus-within /template/ TextBlock#floatingWatermark">
+      <Setter Property="Margin" Value="0,2"/>
+    </Style>
+
   </ControlTheme>
 </ResourceDictionary>


### PR DESCRIPTION
* added .dense class to ComboBox Theme as an equivalent to the TextBox Theme
* Changed vOffset from -8 to -4 in RectHollowClipConverter as it interfered with clipping in border when in dense class and nothing was selected and not focused (floating label is in control and not in border so clipping should amso not occur). Doesn't seem to have an impact on other controls in demopages for TextBoxes and ComboBoxes
* Added ComboBoxDense in ComboBoxesDemo page