### PR TITLE
Add `Material.Avalonia.TreeDataGrid` project with TreeDataGrid styles

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,6 +12,7 @@
     <PackageVersion Include="Avalonia" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Controls.DataGrid" Version="$(AvaloniaVersion)" />
+    <PackageVersion Include="Avalonia.Controls.TreeDataGrid" Version="11.1.0" />
     <PackageVersion Include="Avalonia.Controls.ItemsRepeater" Version="11.0.9" />
     <PackageVersion Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Themes.Simple" Version="$(AvaloniaVersion)" />

--- a/Material.Avalonia.TreeDataGrid/Converters/TreeDataGridSourceColumnAlignmentToDockConverter.cs
+++ b/Material.Avalonia.TreeDataGrid/Converters/TreeDataGridSourceColumnAlignmentToDockConverter.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Avalonia.Controls;
+using Avalonia.Data.Converters;
+using Avalonia.Media;
+
+namespace Material.Avalonia.TreeDataGrid.Converters;
+
+public sealed class TreeDataGridSourceColumnAlignmentToDockConverter : IMultiValueConverter
+{
+    public object? Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (values[0] is not ITreeDataGridSource source ||
+            values[1] is not int columnIndex || 
+            columnIndex < 0 || 
+            columnIndex >= source.Columns.Count)
+            return Dock.Left;
+
+        var column = source.Columns[columnIndex];
+        var align  = TextColumnAlignmentProvider.GetTextAlignment(column);
+
+        return align == TextAlignment.Right ? Dock.Right : Dock.Left;
+    }
+
+    public object[] ConvertBack(object? value, Type[] targetTypes, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}

--- a/Material.Avalonia.TreeDataGrid/Material.Avalonia.TreeDataGrid.csproj
+++ b/Material.Avalonia.TreeDataGrid/Material.Avalonia.TreeDataGrid.csproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  
+  <PropertyGroup>
+    <Description>TreeDataGrid styles library of Material.Avalonia.</Description>
+    <PackageTags>avalonia xaml material design theme treedatagrid colour color ui ux material-design google-material</PackageTags>
+    <PackageIcon>FavIcon.png</PackageIcon>
+
+    <TargetFrameworks>net8.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="../wiki/FavIcon.png" Pack="true" PackagePath="/" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Avalonia.Controls.TreeDataGrid" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Material.Avalonia\Material.Avalonia.csproj"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="*.props">
+      <Pack>true</Pack>
+      <PackagePath>build\;buildTransitive\</PackagePath>
+    </Content>
+  </ItemGroup>
+
+</Project>

--- a/Material.Avalonia.TreeDataGrid/Material.Avalonia.TreeDataGrid.props
+++ b/Material.Avalonia.TreeDataGrid/Material.Avalonia.TreeDataGrid.props
@@ -1,0 +1,7 @@
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <RuntimeHostConfigurationOption Include="MaterialThemeIncludeTreeDataGrid" Value="true"/>
+    <!--To exclude this library from trimming-->
+    <TrimmerRootAssembly Include="Material.Avalonia.TreeDataGrid" RootMode="library"/>
+  </ItemGroup>
+</Project>

--- a/Material.Avalonia.TreeDataGrid/MaterialTreeDataGridStyles.axaml
+++ b/Material.Avalonia.TreeDataGrid/MaterialTreeDataGridStyles.axaml
@@ -1,0 +1,12 @@
+<treeDataGrid:MaterialTreeDataGridStyles xmlns="https://github.com/avaloniaui"
+                                 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                                 xmlns:treeDataGrid="clr-namespace:Material.Avalonia.TreeDataGrid"
+                                 x:Class="Material.Avalonia.TreeDataGrid.MaterialTreeDataGridStyles">
+  <treeDataGrid:MaterialTreeDataGridStyles.Resources>
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <ResourceInclude Source="avares://Material.Avalonia.TreeDataGrid/TreeDataGrid.axaml" />
+      </ResourceDictionary.MergedDictionaries>
+    </ResourceDictionary>
+  </treeDataGrid:MaterialTreeDataGridStyles.Resources>
+</treeDataGrid:MaterialTreeDataGridStyles>

--- a/Material.Avalonia.TreeDataGrid/MaterialTreeDataGridStyles.axaml.cs
+++ b/Material.Avalonia.TreeDataGrid/MaterialTreeDataGridStyles.axaml.cs
@@ -1,0 +1,4 @@
+namespace Material.Avalonia.TreeDataGrid;
+
+public class MaterialTreeDataGridStyles : global::Avalonia.Styling.Styles {
+}

--- a/Material.Avalonia.TreeDataGrid/TextColumnAlignmentProvider.cs
+++ b/Material.Avalonia.TreeDataGrid/TextColumnAlignmentProvider.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using Avalonia.Controls.Models.TreeDataGrid;
+using Avalonia.Media;
+
+namespace Material.Avalonia.TreeDataGrid;
+
+internal static class TextColumnAlignmentProvider
+{
+    private static readonly ConcurrentDictionary<Type, Func<object, TextAlignment?>> _cache = new();
+
+    public static TextAlignment? GetTextAlignment(object column)
+    {
+        ArgumentNullException.ThrowIfNull(column);
+
+        var colType = column.GetType();
+        if (!colType.IsGenericType
+            || colType.GetGenericTypeDefinition() != typeof(TextColumn<,>))
+            return null;
+
+        var getter = _cache.GetOrAdd(colType, BuildGetter);
+        return getter(column);
+    }
+
+    [UnconditionalSuppressMessage("AOT", "IL3050:Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.", Justification = "<Pending>")]
+    private static Func<object, TextAlignment?> BuildGetter(Type closedColumnType)
+    {
+        var helperMethod = typeof(TextColumnHelper)
+            .GetMethod(nameof(TextColumnHelper.GetTextAlignmentGeneric),
+                BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public)!;
+
+        var genArgs = closedColumnType.GetGenericArguments();
+        var closedMethod = helperMethod.MakeGenericMethod(genArgs);
+
+        return (Func<object, TextAlignment?>)closedMethod
+            .CreateDelegate(typeof(Func<object, TextAlignment?>));
+    }
+}

--- a/Material.Avalonia.TreeDataGrid/TextColumnHelper.cs
+++ b/Material.Avalonia.TreeDataGrid/TextColumnHelper.cs
@@ -1,0 +1,14 @@
+using Avalonia.Controls.Models.TreeDataGrid;
+using Avalonia.Media;
+
+namespace Material.Avalonia.TreeDataGrid;
+
+internal static class TextColumnHelper
+{
+    public static TextAlignment? GetTextAlignmentGeneric<TModel, TValue>(object column)
+        where TModel : class
+    {
+        var typed = (TextColumn<TModel, TValue>)column;
+        return typed.Options.TextAlignment;
+    }
+}

--- a/Material.Avalonia.TreeDataGrid/TreeDataGrid.axaml
+++ b/Material.Avalonia.TreeDataGrid/TreeDataGrid.axaml
@@ -1,0 +1,463 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:ripple="clr-namespace:Material.Ripple;assembly=Material.Ripple"
+                    xmlns:converters="clr-namespace:Material.Styles.Converters;assembly=Material.Styles"
+                    xmlns:parameters="clr-namespace:Material.Styles.Converters.Parameters;assembly=Material.Styles"
+                    xmlns:treeDataGridConverters="clr-namespace:Material.Avalonia.TreeDataGrid.Converters">
+  
+  <StreamGeometry x:Key="TreeDataGridSortIconPath">M436-148v-497.08L210.15-419.23 148-481l331-331 333 333-62.15 61.77L522-645.08V-148h-86Z</StreamGeometry>
+  <StreamGeometry x:Key="TreeDataGridItemChevronPathData">M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z</StreamGeometry>
+
+  <treeDataGridConverters:TreeDataGridSourceColumnAlignmentToDockConverter x:Key="TreeDataGridSourceColumnAlignmentToDockConverter" />
+  <converters:BrushRoundConverter x:Key="BrushRoundConverter" />
+  <converters:MarginMultiplyConverter x:Key="MarginCreator" />
+  <parameters:MarginMultiplyParameter x:Key="TreeItemContentMargin" LeftMultiplier="28" />
+  
+  <ControlTheme x:Key="{x:Type TreeDataGrid}" TargetType="TreeDataGrid">
+    <Setter Property="CornerRadius" Value="4" />
+    <Setter Property="BorderBrush" Value="{DynamicResource MaterialDividerBrush}" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Border x:Name="RootBorder"
+                Background="{TemplateBinding Background}"
+                BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="{TemplateBinding BorderThickness}"
+                CornerRadius="{TemplateBinding CornerRadius}">
+          <DockPanel>
+             <ScrollViewer x:Name="PART_HeaderScrollViewer"
+                           DockPanel.Dock="Top"
+                           IsVisible="{TemplateBinding ShowColumnHeaders}"
+                           HorizontalScrollBarVisibility="Hidden"
+                           VerticalScrollBarVisibility="Disabled"
+                           BringIntoViewOnFocusChange="{TemplateBinding (ScrollViewer.BringIntoViewOnFocusChange)}">
+                <Border x:Name="ColumnHeadersPresenterBorder">
+                  <TreeDataGridColumnHeadersPresenter x:Name="PART_ColumnHeadersPresenter"
+                                                      ElementFactory="{TemplateBinding ElementFactory}"
+                                                      Items="{TemplateBinding Columns}" />
+                </Border>
+             </ScrollViewer>
+            <ScrollViewer x:Name="PART_ScrollViewer"
+                          HorizontalScrollBarVisibility="Auto"
+                          BringIntoViewOnFocusChange="{TemplateBinding (ScrollViewer.BringIntoViewOnFocusChange)}">
+              <TreeDataGridRowsPresenter x:Name="PART_RowsPresenter"
+                                         Columns="{TemplateBinding Columns}"
+                                         ElementFactory="{TemplateBinding ElementFactory}"
+                                         Items="{TemplateBinding Rows}" />
+            </ScrollViewer>
+          </DockPanel>
+        </Border>
+      </ControlTemplate>
+    </Setter>
+    
+    <Style Selector="^ /template/ Border#ColumnHeadersPresenterBorder">
+      <Setter Property="BorderThickness" Value="0 0 0 1" />
+      <Setter Property="BorderBrush" Value="{TemplateBinding BorderBrush}" />
+    </Style>
+    
+    <Style Selector="^ /template/ ScrollViewer">
+      <Setter Property="Theme" Value="{StaticResource MaterialModernScrollViewer}" />
+    </Style>
+
+    <!-- Template for classic scrollviewers -->
+    <Style Selector="^.ClassicScrollViewer /template/ ScrollViewer">
+      <Setter Property="Theme" Value="{StaticResource MaterialScrollViewer}" />
+    </Style>
+    
+    <Style Selector="^.DisableHoveringScrollViewer /template/ ScrollViewer">
+      <Setter Property="Margin" Value="0" />
+      <Style Selector="^:horizontal">
+        <Setter Property="Height" Value="{DynamicResource ScrollBarThickness}" />
+      </Style>
+      <Style Selector="^:vertical">
+        <Setter Property="Height" Value="{DynamicResource ScrollBarThickness}" />
+      </Style>
+    </Style>
+  </ControlTheme>
+  
+  <ControlTheme x:Key="{x:Type TreeDataGridColumnHeader}" TargetType="TreeDataGridColumnHeader">
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="MinHeight" Value="56" />
+    <Setter Property="Foreground" Value="{DynamicResource MaterialColumnHeaderBrush}" />
+    <Setter Property="FontWeight" Value="Bold" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Border x:Name="DataGridBorder"
+                Background="{TemplateBinding Background}"
+                BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="{TemplateBinding BorderThickness}"
+                CornerRadius="{TemplateBinding CornerRadius}"
+                Padding="16 0 0 0">
+          <DockPanel LastChildFill="False">
+            <Panel DockPanel.Dock="Right"
+                   Margin="11 0 0 0"
+                   TabIndex="2">
+              <Rectangle Fill="{DynamicResource MaterialDividerBrush}"
+                         HorizontalAlignment="Right"
+                         Height="14"
+                         Width="2" />
+              <Thumb x:Name="PART_Resizer"
+                     DockPanel.Dock="Right"
+                     Background="Transparent"
+                     Cursor="SizeWestEast"
+                     IsVisible="{TemplateBinding CanUserResize}"
+                     Width="5">
+                <Thumb.Template>
+                  <ControlTemplate>
+                    <Border Background="{TemplateBinding Background}"
+                            VerticalAlignment="Stretch" />
+                  </ControlTemplate>
+                </Thumb.Template>
+              </Thumb>
+            </Panel>
+            
+            <ContentPresenter x:Name="PART_ContentPresenter"
+                              Content="{TemplateBinding Header}"
+                              ContentTemplate="{TemplateBinding ContentTemplate}"
+                              HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                              VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                              TabIndex="0">
+              <DockPanel.Dock>
+                <MultiBinding Converter="{StaticResource TreeDataGridSourceColumnAlignmentToDockConverter}">
+                  <Binding Path="$parent[TreeDataGrid].Source" />
+                  <Binding Path="$parent[TreeDataGridColumnHeader].ColumnIndex" />
+                </MultiBinding>
+              </DockPanel.Dock>
+              
+              <ContentPresenter.DataTemplates>
+                <DataTemplate DataType="x:String">
+                  <TextBlock Text="{Binding}"
+                             ToolTip.Tip="{Binding}"
+                             TextTrimming="CharacterEllipsis" />
+                </DataTemplate>
+              </ContentPresenter.DataTemplates>
+            </ContentPresenter>
+            
+            <Path x:Name="SortIcon"
+                  Fill="{TemplateBinding Foreground}"
+                  Opacity="0.6"
+                  HorizontalAlignment="Left"
+                  VerticalAlignment="Center"
+                  Width="14"
+                  Margin="8 0"
+                  TabIndex="1"
+                  Stretch="Uniform"
+                  Data="{DynamicResource TreeDataGridSortIconPath}">
+              <DockPanel.Dock>
+                <MultiBinding Converter="{StaticResource TreeDataGridSourceColumnAlignmentToDockConverter}">
+                  <Binding Path="$parent[TreeDataGrid].Source" />
+                  <Binding Path="$parent[TreeDataGridColumnHeader].ColumnIndex" />
+                </MultiBinding>
+              </DockPanel.Dock>
+            </Path>
+          </DockPanel>
+        </Border>
+      </ControlTemplate>
+    </Setter>
+
+    <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Opacity" Value="0.8" />
+    </Style>
+    
+    <Style Selector="^:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Opacity" Value="1" />
+    </Style>
+    
+    <Style Selector="^:not(.no-transitions) /template/ Path#SortIcon">
+      <Setter Property="Transitions">
+        <Transitions>
+          <TransformOperationsTransition Duration="0:0:0.25" Property="RenderTransform" Easing="CircularEaseOut" />
+        </Transitions>
+      </Setter>
+    </Style>
+    
+    <Style Selector="^ /template/ Path#SortIcon">
+      <Setter Property="IsVisible" Value="False" />
+      <Setter Property="RenderTransformOrigin" Value="7,7" />
+      <Setter Property="RenderTransform" Value="rotate(90deg)" />
+    </Style>
+    
+    <Style Selector="^[SortDirection=Ascending] /template/ Path#SortIcon">
+      <Setter Property="IsVisible" Value="True" />
+      <Setter Property="RenderTransform" Value="rotate(0deg)" />
+    </Style>
+
+    <Style Selector="^[SortDirection=Descending] /template/ Path#SortIcon">
+      <Setter Property="IsVisible" Value="True" />
+      <Setter Property="RenderTransform" Value="rotate(180deg)" />
+    </Style>
+
+  </ControlTheme>
+
+  <ControlTheme x:Key="{x:Type TreeDataGridRow}" TargetType="TreeDataGridRow">
+    <Setter Property="MinHeight" Value="52" />
+    <Setter Property="BorderBrush" Value="{Binding Path=$parent[TreeDataGrid].BorderBrush}" />
+    <Setter Property="BorderThickness" Value="0 0 0 1" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Border x:Name="RowBorder"
+                Background="{TemplateBinding Background}"
+                BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="{TemplateBinding BorderThickness}"
+                CornerRadius="{TemplateBinding CornerRadius}">
+          <Panel x:Name="PART_InnerPanel">
+            <Border x:Name="PART_BehaviourEffect" />
+            
+            <TreeDataGridCellsPresenter x:Name="PART_CellsPresenter"
+                                        ElementFactory="{TemplateBinding ElementFactory}"
+                                        Items="{TemplateBinding Columns}"
+                                        Rows="{TemplateBinding Rows}" />
+            
+            <Border x:Name="PART_HoverEffect" />
+          </Panel>
+        </Border>
+      </ControlTemplate>
+    </Setter>
+
+    <!-- Transitions -->
+    <Style Selector="^:not(.no-transitions)">
+      <Style Selector="^ /template/ Border#PART_BehaviourEffect">
+        <Setter Property="Transitions">
+          <Transitions>
+            <DoubleTransition Duration="0:0:0.25" Property="Opacity" Easing="LinearEasing" />
+          </Transitions>
+        </Setter>
+      </Style>
+      
+      <Style Selector="^ /template/ Border#PART_HoverEffect">
+        <Setter Property="Transitions">
+          <Transitions>
+            <DoubleTransition Duration="0:0:0.05" Property="Opacity" Easing="LinearEasing" />
+          </Transitions>
+        </Setter>
+      </Style>
+    </Style>
+    
+    <!-- Statements for transition elements -->
+
+    <!-- Default statement - behaviour effect border should have invisible (full-transparent) -->
+    <Style Selector="^ /template/ Border#PART_BehaviourEffect">
+      <Setter Property="Background" Value="{DynamicResource MaterialBodyBrush}" />
+      <Setter Property="Opacity" Value="0" />
+    </Style>
+    
+    <Style Selector="^ /template/ Border#PART_HoverEffect">
+      <Setter Property="Background" Value="{DynamicResource MaterialBodyBrush}" />
+      <Setter Property="IsHitTestVisible" Value="False" />
+      <Setter Property="Opacity" Value="0" />
+    </Style>
+    
+    <!-- Set behaviour effect highlight to semi-transparent barely visible when cursor hovering TreeViewItem -->
+    <Style Selector="^ /template/ Border#RowBorder:pointerover Border#PART_HoverEffect">
+      <Setter Property="Opacity" Value="0.05" />
+    </Style>
+
+    <!-- Set behaviour effect highlight to semi-transparent visible when user selected TreeViewItem -->
+    <Style Selector="^:selected /template/ Border#PART_BehaviourEffect">
+      <Setter Property="Opacity" Value="0.24" />
+    </Style>
+  </ControlTheme>
+
+  <ControlTheme x:Key="{x:Type TreeDataGridCheckBoxCell}" TargetType="TreeDataGridCheckBoxCell">
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Border x:Name="CellBorder"
+                Background="{TemplateBinding Background}"
+                BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="{TemplateBinding BorderThickness}"
+                CornerRadius="{TemplateBinding CornerRadius}"
+                Padding="{TemplateBinding Padding}">
+          <CheckBox x:Name="PART_CheckBox"
+                    IsChecked="{TemplateBinding Value, Mode=TwoWay}"
+                    IsEnabled="{Binding !IsReadOnly, RelativeSource={RelativeSource TemplatedParent}}"
+                    IsThreeState="{TemplateBinding IsThreeState}">
+            <CheckBox.Styles>
+              <Style Selector="CheckBox /template/ DockPanel#PART_RootPanel">
+                <Setter Property="HorizontalAlignment" Value="Center" />
+              </Style>
+            </CheckBox.Styles>
+          </CheckBox>
+        </Border>
+      </ControlTemplate>
+    </Setter>
+    
+    <Style Selector="^">
+      <Setter Property="Focusable" Value="False" />
+      <Setter Property="MinWidth" Value="56" />
+      <Setter Property="Padding" Value="8 6" />
+    </Style>
+    
+    <Style Selector="^ /template/ CheckBox#PART_CheckBox">
+      <Setter Property="Width" Value="40" />
+      <Setter Property="Padding" Value="0" />
+    </Style>
+  </ControlTheme>
+
+  <ControlTheme x:Key="TreeDataGridExpandToggleButton" TargetType="ToggleButton">
+    <Setter Property="Cursor" Value="Hand" />
+    <Setter Property="Focusable" Value="False" />
+    <Setter Property="CornerRadius" Value="16" />
+    <Setter Property="Margin" Value="8 0" />
+    <Setter Property="Width" Value="24" />
+    <Setter Property="Height" Value="24" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Border Background="Transparent"
+                CornerRadius="{TemplateBinding CornerRadius}"
+                ClipToBounds="True">
+          <Panel x:Name="PART_InnerPanel"
+                 Width="24"
+                 Height="24">
+            <Path x:Name="ChevronPath"
+                  Data="{StaticResource TreeDataGridItemChevronPathData}"
+                  Fill="{TemplateBinding Foreground}"
+                  Stroke="{TemplateBinding Foreground}" />
+          </Panel>
+        </Border>
+      </ControlTemplate>
+    </Setter>
+    
+    <Style Selector="^:not(.no-transitions) /template/ Panel#PART_InnerPanel">
+      <Setter Property="Transitions">
+        <Transitions>
+          <TransformOperationsTransition Duration="0:0:0.25" Property="RenderTransform" Easing="CircularEaseOut" />
+        </Transitions>
+      </Setter>
+    </Style>
+    
+    <Style Selector="^ /template/ Panel#PART_InnerPanel">
+      <Setter Property="RenderTransform" Value="rotate(0deg)" />
+    </Style>
+    
+    <Style Selector="^:checked /template/ Panel#PART_InnerPanel">
+      <Setter Property="RenderTransform" Value="rotate(45deg)" />
+    </Style>
+  </ControlTheme>
+
+  <ControlTheme x:Key="{x:Type TreeDataGridExpanderCell}" TargetType="TreeDataGridExpanderCell">
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Border x:Name="PART_RootBorder"
+                Background="{TemplateBinding Background}"
+                BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="{TemplateBinding BorderThickness}"
+                CornerRadius="{TemplateBinding CornerRadius}">
+          <Panel x:Name="PART_InnerPanel">
+            <ripple:RippleEffect x:Name="PART_Ripple">
+              <DockPanel x:Name="PART_ContentPanel"
+                         Margin="{TemplateBinding Indent,
+                         Converter={StaticResource MarginCreator}, 
+                         ConverterParameter={StaticResource TreeItemContentMargin}}">
+                  <ToggleButton x:Name="PART_ExpanderButton"
+                                DockPanel.Dock="Left"
+                                Focusable="False"
+                                IsChecked="{TemplateBinding IsExpanded, Mode=TwoWay}"
+                                IsVisible="{TemplateBinding ShowExpander}" />
+                
+                <Decorator DockPanel.Dock="Right"
+                           x:Name="PART_Content" />
+              </DockPanel>
+            </ripple:RippleEffect>
+          </Panel>
+        </Border>
+      </ControlTemplate>
+    </Setter>
+    
+    <Style Selector="^ /template/ ToggleButton#PART_ExpanderButton">
+      <Setter Property="Theme" Value="{StaticResource TreeDataGridExpandToggleButton}" />
+    </Style>
+    
+    <Style Selector="^ /template/ ripple|RippleEffect#PART_Ripple">
+      <Setter Property="RippleFill" Value="{DynamicResource MaterialBodyBrush}" />
+      <Setter Property="Focusable" Value="False" />
+    </Style>
+
+    <Style Selector="^:disabled /template/ Border#PART_RootBorder">
+      <Setter Property="Opacity" Value="0.56" />
+    </Style>
+
+    <Style Selector="^:empty /template/ ToggleButton#PART_ExpanderButton">
+      <Setter Property="Opacity" Value="0" />
+      <Setter Property="IsEnabled" Value="False" />
+    </Style>
+  </ControlTheme>
+
+  <ControlTheme x:Key="{x:Type TreeDataGridTextCell}" TargetType="TreeDataGridTextCell">
+    <Setter Property="Padding" Value="16 0" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Border x:Name="CellBorder"
+                Background="{TemplateBinding Background}"
+                BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="{TemplateBinding BorderThickness}"
+                CornerRadius="{TemplateBinding CornerRadius}"
+                Padding="{TemplateBinding Padding}">
+          <TextBlock Text="{TemplateBinding Value}"
+                     TextTrimming="{TemplateBinding TextTrimming}"
+                     TextWrapping="{TemplateBinding TextWrapping}"
+                     TextAlignment="{TemplateBinding TextAlignment}"
+                     VerticalAlignment="Center" />
+        </Border>
+      </ControlTemplate>
+    </Setter>
+
+    <Style Selector="^:editing">
+      <Setter Property="Template">
+        <ControlTemplate>
+          <Border x:Name="CellBorder"
+                  Background="{TemplateBinding Background}"
+                  BorderBrush="{TemplateBinding BorderBrush}"
+                  BorderThickness="{TemplateBinding BorderThickness}"
+                  CornerRadius="{TemplateBinding CornerRadius}"
+                  Padding="{TemplateBinding Padding}">
+            <TextBox x:Name="PART_Edit"
+                     Classes="dense"
+                     TextAlignment="{TemplateBinding TextAlignment}"
+                     VerticalAlignment="Center"
+                     Text="{TemplateBinding Value, Mode=TwoWay}" />
+          </Border>
+        </ControlTemplate>
+      </Setter>
+    </Style>
+
+    <Style Selector="^:editing /template/ TextBox#PART_Edit">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="VerticalAlignment" Value="Center" />
+    </Style>
+
+    <Style Selector="^:editing /template/ TextBox#PART_Edit DataValidationErrors">
+      <Setter Property="Template" Value="{DynamicResource TooltipDataValidationContentTemplate}" />
+      <Setter Property="ErrorTemplate" Value="{DynamicResource TooltipDataValidationErrorTemplate}" />
+    </Style>
+  </ControlTheme>
+
+  <ControlTheme x:Key="{x:Type TreeDataGridTemplateCell}" TargetType="TreeDataGridTemplateCell">
+    <Setter Property="Template">
+      <ControlTemplate>
+        <ContentPresenter x:Name="PART_ContentPresenter"
+                          Background="{TemplateBinding Background}"
+                          BorderBrush="{TemplateBinding BorderBrush}"
+                          BorderThickness="{TemplateBinding BorderThickness}"
+                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                          CornerRadius="{TemplateBinding CornerRadius}"
+                          Content="{TemplateBinding Content}"
+                          Padding="{TemplateBinding Padding}" />
+      </ControlTemplate>
+    </Setter>
+
+    <Style Selector="^:editing">
+      <Setter Property="Template">
+        <ControlTemplate>
+          <ContentPresenter x:Name="PART_EditingContentPresenter"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            ContentTemplate="{TemplateBinding EditingTemplate}"
+                            CornerRadius="{TemplateBinding CornerRadius}"
+                            Content="{TemplateBinding Content}"
+                            Padding="{TemplateBinding Padding}" />
+        </ControlTemplate>
+      </Setter>
+    </Style>
+  </ControlTheme>
+</ResourceDictionary>

--- a/Material.Avalonia.TreeDataGrid/TreeDataGrid.xaml
+++ b/Material.Avalonia.TreeDataGrid/TreeDataGrid.xaml
@@ -1,0 +1,12 @@
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  
+  <!-- Deprecated, will be removed in next major release -->
+  <Styles.Resources>
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <ResourceInclude Source="avares://Material.Avalonia.TreeDataGrid/TreeDataGrid.axaml" />
+      </ResourceDictionary.MergedDictionaries>
+    </ResourceDictionary>
+  </Styles.Resources>
+</Styles>

--- a/Material.Avalonia.sln
+++ b/Material.Avalonia.sln
@@ -33,6 +33,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Demo", "Demo", "{306F0023-F
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Material.Avalonia.Demo", "Material.Avalonia.Demo\Material.Avalonia.Demo.csproj", "{0A1A6ED0-B306-4EC7-9839-E1FCB2CC3485}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Material.Avalonia.TreeDataGrid", "Material.Avalonia.TreeDataGrid\Material.Avalonia.TreeDataGrid.csproj", "{5B6C95A6-5620-45C7-A1B8-B8EC5D9D70F5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -75,6 +77,10 @@ Global
 		{0A1A6ED0-B306-4EC7-9839-E1FCB2CC3485}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0A1A6ED0-B306-4EC7-9839-E1FCB2CC3485}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0A1A6ED0-B306-4EC7-9839-E1FCB2CC3485}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5B6C95A6-5620-45C7-A1B8-B8EC5D9D70F5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5B6C95A6-5620-45C7-A1B8-B8EC5D9D70F5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5B6C95A6-5620-45C7-A1B8-B8EC5D9D70F5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5B6C95A6-5620-45C7-A1B8-B8EC5D9D70F5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary

This PR adds a basic Material-styled theme for `TreeDataGrid` in Material.Avalonia.

## Motivation

I needed `TreeDataGrid` to display a hierarchical structure with virtualization, but noticed that `Material.Avalonia` doesn't currently include any styling for it.

To keep visual consistency, I created a custom style by referencing:
- existing `TreeView` and `DataGrid` styles from this theme
- WPF implementation of Material Design in XAML
- and the official Material Design spec for data tables: https://m2.material.io/components/data-tables

## Implementation Notes

- The style is currently implemented without a demo.
- For testing or future demonstration, you can use the sample from the official Avalonia TreeDataGrid repo:  
  https://github.com/AvaloniaUI/Avalonia.Controls.TreeDataGrid/tree/master/samples/TreeDataGridDemo

## Screenshots

### Tree inside TreeDataGrid
<img width="456" height="616" alt="image" src="https://github.com/user-attachments/assets/d31c3491-92f3-4d54-834d-a806fb4f104b" />


### Table
<img width="799" height="934" alt="image" src="https://github.com/user-attachments/assets/957080e7-21bf-4ac1-921e-9cddb618afcc" />

