### PR TITLE
Add keyboard focus visual indicator for some controls

### DIFF
--- a/Material.Styles/Controls/FloatingButton.axaml
+++ b/Material.Styles/Controls/FloatingButton.axaml
@@ -18,6 +18,7 @@
 
     <Setter Property="HorizontalContentAlignment" Value="Stretch" />
     <Setter Property="VerticalContentAlignment" Value="Stretch" />
+    <Setter Property="FocusAdorner" Value="{x:Null}"/>
     <Setter Property="Background" Value="{DynamicResource MaterialPrimaryMidBrush}" />
     <Setter Property="BorderBrush" Value="{DynamicResource MaterialPrimaryMidBrush}" />
     <Setter Property="Foreground" Value="{DynamicResource MaterialPrimaryMidForegroundBrush}" />
@@ -133,7 +134,14 @@
     <Style Selector="^:pointerover:not(.no-material) /template/ Border#PART_HoverIndicator">
       <Setter Property="Opacity" Value="{StaticResource ButtonHoveredOpacity}" />
     </Style>
-
+    
+    <Style Selector="^:pointerover:not(.no-material) /template/ Border#PART_ButtonRootBorder">
+      <Setter Property="assists:ShadowAssist.Darken" Value="True" />
+    </Style>
+    
+    <Style Selector="^:focus-visible:not(.no-material) /template/ Border#PART_HoverIndicator">
+      <Setter Property="Opacity" Value="{StaticResource ButtonHoveredOpacity}" />
+    </Style>
 
     <!-- Mini and extended style -->
 

--- a/Material.Styles/Resources/Themes/Button.axaml
+++ b/Material.Styles/Resources/Themes/Button.axaml
@@ -13,6 +13,7 @@
     <Setter Property="CornerRadius" Value="4" />
     <Setter Property="HorizontalContentAlignment" Value="Center" />
     <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="FocusAdorner" Value="{x:Null}"></Setter>
     <Setter Property="Cursor" Value="Hand" />
     <Setter Property="Padding" Value="16 8" />
     <Setter Property="assists:ButtonAssist.HoverColor"
@@ -108,6 +109,10 @@
       <Setter Property="Opacity" Value="0.24" />
     </Style>
 
+    <Style Selector="^:focus-visible /template/ Border#PART_HoverEffect">
+      <Setter Property="Opacity" Value="0.20" />
+    </Style>
+
     <Style Selector="^:pointerover /template/ Border#PART_RootBorder">
       <Setter Property="assists:ShadowAssist.Darken" Value="True" />
     </Style>
@@ -115,11 +120,11 @@
     <Style Selector="^:disabled /template/ Border#PART_RootBorder">
       <Setter Property="Opacity" Value="{StaticResource ButtonDisabledOpacity}" />
     </Style>
-    
+
     <Style Selector="^.icon">
       <Setter Property="Background" Value="Transparent" />
       <Setter Property="assists:ShadowAssist.ShadowDepth" Value="Depth0" />
-      
+
       <Setter Property="Padding" Value="12" />
       <Setter Property="CornerRadius" Value="24" />
       <Setter Property="Height" Value="48" />

--- a/Material.Styles/Resources/Themes/ComboBox.axaml
+++ b/Material.Styles/Resources/Themes/ComboBox.axaml
@@ -35,6 +35,7 @@
   <!-- Default -->
   <ControlTheme x:Key="MaterialComboBox" TargetType="ComboBox">
     <Setter Property="Background" Value="Transparent" />
+    <Setter Property="FocusAdorner" Value="{x:Null}"></Setter>
     <Setter Property="PlaceholderForeground" Value="{DynamicResource MaterialBodyBrush}" />
     <Setter Property="HorizontalContentAlignment" Value="Stretch" />
     <Setter Property="HorizontalAlignment" Value="Stretch" />
@@ -169,6 +170,7 @@
       <ControlTemplate>
         <StackPanel Name="PART_TemplateRoot">
           <ToggleButton Classes="no-ripple"
+                        Focusable="False"
                         MinHeight="48" BorderThickness="0"
                         HorizontalContentAlignment="Stretch"
                         IsChecked="{TemplateBinding IsDropDownOpen, Mode=TwoWay}"
@@ -276,6 +278,9 @@
     </Style>
     <Style Selector="^[IsDropDownOpen=false] /template/ TextBlock#floatingWatermark">
       <Setter Property="Margin" Value="10,20,1,1" />
+    </Style>
+    <Style Selector="^:focus-within /template/ controls|MaterialUnderline#Underline">
+      <Setter Property="IsActive" Value="True" />
     </Style>
   </ControlTheme>
 

--- a/Material.Styles/Resources/Themes/ComboBoxItem.axaml
+++ b/Material.Styles/Resources/Themes/ComboBoxItem.axaml
@@ -3,6 +3,7 @@
                     xmlns:ripple="clr-namespace:Material.Ripple;assembly=Material.Ripple">
   <ControlTheme x:Key="MaterialComboBoxItem" TargetType="ComboBoxItem">
     <Setter Property="Padding" Value="16, 8" />
+    <Setter Property="FocusAdorner" Value="{x:Null}"></Setter>
     <Setter Property="BorderThickness" Value="0" />
     <Setter Property="HorizontalAlignment" Value="Stretch" />
     <Setter Property="HorizontalContentAlignment" Value="Left" />
@@ -31,6 +32,12 @@
     </Style>
     <Style Selector="^:pressed /template/ Border#PointerOverBorder">
       <Setter Property="Opacity" Value="0.15" />
+    </Style>
+    <Style Selector="^:pointerover /template/ Border#PointerOverBorder">
+      <Setter Property="Opacity" Value="0.12" />
+    </Style>
+    <Style Selector="^:focus-visible /template/ Border#PointerOverBorder">
+      <Setter Property="Opacity" Value="0.12" />
     </Style>
   </ControlTheme>
 

--- a/Material.Styles/Resources/Themes/Expander.axaml
+++ b/Material.Styles/Resources/Themes/Expander.axaml
@@ -5,6 +5,7 @@
   <ControlTheme x:Key="ExpanderToggleButtonPart" TargetType="ToggleButton">
     <Setter Property="Background" Value="Transparent" />
     <Setter Property="ClipToBounds" Value="False" />
+    <Setter Property="FocusAdorner" Value="{x:Null}"></Setter>
     <Setter Property="Height" Value="48" />
     <Setter Property="assists:ToggleButtonAssist.UncheckedBackground" Value="Transparent" />
     <Setter Property="HorizontalAlignment" Value="Stretch"/>
@@ -49,6 +50,11 @@
           <TransformOperationsTransition Property="RenderTransform" Duration="0.25" Easing="CubicEaseOut" />
         </Transitions>
       </Setter>
+    </Style>
+    
+    <Style Selector="^:focus-visible">
+      <Setter Property="BorderThickness" Value="2"/>
+      <Setter Property="BorderBrush" Value="{DynamicResource MaterialPrimaryLightBrush}"/>
     </Style>
 
     <Style Selector="^ /template/ Border#PART_RootBorder">

--- a/Material.Styles/Resources/Themes/HyperlinkButton.axaml
+++ b/Material.Styles/Resources/Themes/HyperlinkButton.axaml
@@ -13,6 +13,7 @@
   <!-- actual control theme -->
   <ControlTheme x:Key="MaterialHyperlinkButton" TargetType="HyperlinkButton">
     <Setter Property="Cursor" Value="Hand" />
+    <Setter Property="FocusAdorner" Value="{x:Null}"/>
     <Setter Property="TextBlock.TextDecorations" Value="Underline" />
     <Setter Property="Template">
       <ControlTemplate>
@@ -37,6 +38,10 @@
     </Style>
 
     <Style Selector="^:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Opacity" Value="1"/>
+    </Style>
+    
+    <Style Selector="^:focus-visible /template/ ContentPresenter#PART_ContentPresenter">
       <Setter Property="Opacity" Value="1"/>
     </Style>
 

--- a/Material.Styles/Resources/Themes/ListBoxItem.axaml
+++ b/Material.Styles/Resources/Themes/ListBoxItem.axaml
@@ -4,6 +4,7 @@
   <ControlTheme x:Key="MaterialListBoxItem" TargetType="ListBoxItem">
     <Setter Property="Background" Value="Transparent" />
     <Setter Property="BorderThickness" Value="0" />
+    <Setter Property="FocusAdorner" Value="{x:Null}"/>
     <Setter Property="Padding" Value="8" />
     <Setter Property="Template">
       <ControlTemplate>
@@ -67,6 +68,10 @@
 
     <Style Selector="^:not(:disabled):pointerover /template/ Border#PART_HoverEffect">
       <Setter Property="Opacity" Value="0.05" />
+    </Style>
+    
+    <Style Selector="^:not(:disabled):focus-visible /template/ Border#PART_HoverEffect">
+      <Setter Property="Opacity" Value="0.07" />
     </Style>
 
     <Style Selector="^:selected /template/ Border#PART_HoverEffect">

--- a/Material.Styles/Resources/Themes/Menu.axaml
+++ b/Material.Styles/Resources/Themes/Menu.axaml
@@ -15,6 +15,7 @@
 
   <ControlTheme x:Key="MaterialTopLevelMenuItem" TargetType="MenuItem">
     <Setter Property="Height" Value="48" />
+    <Setter Property="FocusAdorner" Value="{x:Null}"/>
     <Setter Property="BorderThickness" Value="0" />
     <Setter Property="HorizontalAlignment" Value="Stretch" />
     <Setter Property="Padding" Value="16 0" />
@@ -69,6 +70,10 @@
 
     <Style Selector="^:not(.Menu):not(:disabled):selected /template/ Border#PART_MenuItemHighlighter">
       <Setter Property="Opacity" Value="0.13" />
+    </Style>
+    
+    <Style Selector="^:not(.Menu):not(:disabled):focus-visible /template/ Border#PART_MenuItemHighlighter">
+      <Setter Property="Opacity" Value="0.07" />
     </Style>
   </ControlTheme>
 

--- a/Material.Styles/Resources/Themes/MenuItem.axaml
+++ b/Material.Styles/Resources/Themes/MenuItem.axaml
@@ -65,6 +65,7 @@
     <Setter Property="Height" Value="48" />
     <Setter Property="MinWidth" Value="112" />
     <Setter Property="Padding" Value="0" />
+    <Setter Property="FocusAdorner" Value="{x:Null}"/>
     <Setter Property="BorderThickness" Value="0" />
     <Setter Property="HorizontalAlignment" Value="Stretch" />
     <Setter Property="Foreground" Value="{DynamicResource MaterialBodyBrush}" />
@@ -90,7 +91,6 @@
                   <ContentPresenter Name="PART_Icon"
                                     HorizontalAlignment="Center"
                                     VerticalAlignment="Center"
-
                                     IsVisible="{TemplateBinding Icon, Converter={x:Static ObjectConverters.IsNotNull}}"
                                     Content="{TemplateBinding Icon}" />
                   <ContentPresenter Name="PART_HeaderPresenter"
@@ -159,6 +159,10 @@
 
     <Style Selector="^:not(.Menu):not(:disabled):selected /template/ Border#PART_MenuItemHighlighter">
       <Setter Property="Opacity" Value="0.13" />
+    </Style>
+    
+    <Style Selector="^:not(.Menu):not(:disabled):focus-visible /template/ Border#PART_MenuItemHighlighter">
+      <Setter Property="Opacity" Value="0.07" />
     </Style>
 
     <Style Selector="^:not(.Menu):disabled">

--- a/Material.Styles/Resources/Themes/SplitButton.axaml
+++ b/Material.Styles/Resources/Themes/SplitButton.axaml
@@ -28,8 +28,8 @@
     
     <Setter Property="HorizontalAlignment" Value="Left" />
     <Setter Property="VerticalAlignment" Value="Center" />
-    <Setter Property="KeyboardNavigation.IsTabStop" Value="True" />
-    <Setter Property="Focusable" Value="True" />
+    <Setter Property="KeyboardNavigation.IsTabStop" Value="False" />
+    <Setter Property="Focusable" Value="False" />
     <Setter Property="Template">
       <ControlTemplate>
         <Border Name="PART_RootBorder"
@@ -59,9 +59,9 @@
                     VerticalAlignment="Stretch"
                     HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                     VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                    Focusable="False"
+                    Focusable="True"
                     Padding="{TemplateBinding Padding}"
-                    KeyboardNavigation.IsTabStop="False" />
+                    KeyboardNavigation.IsTabStop="True" />
 
             <Border Name="SeparatorBorder"
                     Grid.Column="1" />
@@ -74,8 +74,8 @@
                     VerticalContentAlignment="Center"
                     HorizontalAlignment="Stretch"
                     VerticalAlignment="Stretch"
-                    Focusable="False"
-                    KeyboardNavigation.IsTabStop="False">
+                    Focusable="True"
+                    KeyboardNavigation.IsTabStop="True">
               <Path Data="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
                     Width="24" Height="24"
                     Name="ExpandPath"/>

--- a/Material.Styles/Resources/Themes/TextBox.axaml
+++ b/Material.Styles/Resources/Themes/TextBox.axaml
@@ -153,6 +153,7 @@
   <!-- The template is compatible for filled and outline text field -->
   <ControlTheme x:Key="MaterialTextBox" TargetType="TextBox">
     <Setter Property="Cursor" Value="IBeam" />
+    <Setter Property="FocusAdorner" Value="{x:Null}"></Setter>
     <Setter Property="Background" Value="Transparent" />
     <Setter Property="SelectionBrush" Value="{DynamicResource MaterialPrimaryMidBrush}" />
     <Setter Property="SelectionForegroundBrush" Value="{DynamicResource MaterialPrimaryMidForegroundBrush}" />

--- a/Material.Styles/Resources/Themes/ToggleButton.axaml
+++ b/Material.Styles/Resources/Themes/ToggleButton.axaml
@@ -56,6 +56,7 @@
 
   <ControlTheme x:Key="MaterialFlatToggleButton" TargetType="ToggleButton">
     <Setter Property="CornerRadius" Value="4" />
+    <Setter Property="FocusAdorner" Value="{x:Null}"></Setter>
     <Setter Property="HorizontalContentAlignment" Value="Center" />
     <Setter Property="VerticalContentAlignment" Value="Center" />
     <Setter Property="BorderThickness" Value="0" />
@@ -111,6 +112,11 @@
     </Style>
 
     <Style Selector="^:not(:disabled):pointerover /template/ Border#PART_HoverEffect">
+      <Setter Property="Opacity" Value="{StaticResource ButtonHoveredOpacity}" />
+      <Setter Property="assists:ShadowAssist.Darken" Value="True" />
+    </Style>
+    
+    <Style Selector="^:not(:disabled):focus-visible /template/ Border#PART_HoverEffect">
       <Setter Property="Opacity" Value="{StaticResource ButtonHoveredOpacity}" />
       <Setter Property="assists:ShadowAssist.Darken" Value="True" />
     </Style>


### PR DESCRIPTION
Technical Changes

- Added focus state handling in some templates
- Extended ripple effect system to support focus state
- Disabled default focus adorner in favor of Material Design visuals
- Added smooth transitions for focus state changes