### PR TITLE
Adjust NavigationDrawer unset ThresholdWidth behavior 

### DIFF
--- a/Material.Styles/Controls/NavigationDrawer.axaml.cs
+++ b/Material.Styles/Controls/NavigationDrawer.axaml.cs
@@ -291,7 +291,7 @@ namespace Material.Styles.Controls
             }
             else
             {
-                _isLeftDrawerDesktopExpanded = false;
+                _isLeftDrawerDesktopExpanded = true;
             }
 
             if (RightDrawerExpandThresholdWidth.HasValue)
@@ -308,7 +308,7 @@ namespace Material.Styles.Controls
             }
             else
             {
-                _isRightDrawerDesktopExpanded = false;
+                _isRightDrawerDesktopExpanded = true;
             }
         }
 


### PR DESCRIPTION
Change behavior for LeftDrawerExpandThresholdWidth/RightDrawerExpandThresholdWidth == null.

The old one: 
- If set - check the width, if less make overlay mode, if more make expanded mode
- If not set - make overlay mode

The new one:
- If set - check the width, if less make overlay mode, if more make expanded mode
- If not set - make **expanded mode**
- (if user wants overlay mode at all time - he can just set double.MaxValue of something like that to that property)

Fix #237