### PR TITLE
Fix ContentTemplate for MenuItem. Fix #487

### DIFF
--- a/Material.Styles/Resources/Themes/MenuItem.axaml
+++ b/Material.Styles/Resources/Themes/MenuItem.axaml
@@ -95,7 +95,8 @@
                                     Content="{TemplateBinding Icon}" />
                   <ContentPresenter Name="PART_HeaderPresenter"
                                     VerticalAlignment="Center"
-                                    Content="{TemplateBinding Header}">
+                                    Content="{TemplateBinding Header}"
+                                    ContentTemplate="{TemplateBinding HeaderTemplate}">
                     <ContentPresenter.DataTemplates>
                       <DataTemplate DataType="system:String">
                         <AccessText Name="PART_MenuItemText"


### PR DESCRIPTION
As stated by title this PR adds `ContentTemplate` to PART_HeaderPresenter of the theme `MaterialMenuItem` so that the property `HeaderTemplate` get considered.

It fixes issue #487.

Thank you.