### PR TITLE
Added values normalization in RangeToSweepConverter

### DIFF
--- a/Material.Styles/Converters/RangeToSweepConverter.cs
+++ b/Material.Styles/Converters/RangeToSweepConverter.cs
@@ -28,8 +28,13 @@ namespace Material.Styles.Converters
             if (values[2] is double maximum)
                 max = maximum;
 
-            var m = max - min;
-            return val / m * 360;
+            // normalize values so 'min' is 0
+            var normMin = min - min;
+            var normVal = val - min;
+            var normMax = max - min;
+
+            var m = normMax - normMin;
+            return normVal / m * 360;
         }
     }
 }


### PR DESCRIPTION
Added values normalization so the correct angles would be applied to circular progress bars.  
Issue:  
The progress bar would be filled 100%:
```xaml
<ProgressBar Classes="circular no-transitions" 
         Minimum="5"
         Maximum="14"
         Value="9"/>
```  
but this one will be filled a bit less than a half:  
```xaml
<ProgressBar Classes="no-transitions" 
         Minimum="5"
         Maximum="14"
         Value="9"/>
```  

Problem location:  
The problem is in  https://github.com/AvaloniaCommunity/Material.Avalonia/blob/04039cd8f5e07ce400a0a0aef2d087be31470348/Material.Styles/Converters/RangeToSweepConverter.cs#L31-L32  

Fix:  
Changed angle calculation.