### PR TITLE
Expander change cursor to hand

### DIFF
--- a/Material.Styles/Resources/Themes/Expander.axaml
+++ b/Material.Styles/Resources/Themes/Expander.axaml
@@ -138,6 +138,7 @@
                 <ToggleButton Name="PART_ToggleButton"
                               Content="{TemplateBinding Header}"
                               ContentTemplate="{TemplateBinding HeaderTemplate}"
+                              Cursor="Hand"
                               Foreground="{DynamicResource MaterialBodyBrush}"
                               IsChecked="{TemplateBinding IsExpanded, Mode=TwoWay}" />
               </LayoutTransformControl>


### PR DESCRIPTION
All buttons have cursor `Hand` as default. The ToggleButton is also a clickable UI element, therefore i propose this change.

The angular material design uses hand as default for the expansion panel, too:
https://material.angular.dev/components/expansion/overview