### PR TITLE
Further improvements to auto complete box

### DIFF
--- a/Material.Avalonia.Demo/Pages/ComboBoxesDemo.axaml
+++ b/Material.Avalonia.Demo/Pages/ComboBoxesDemo.axaml
@@ -4,7 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              xmlns:showMeTheXaml="clr-namespace:ShowMeTheXaml;assembly=ShowMeTheXaml.Avalonia"
-             xmlns:assist="clr-namespace:Material.Styles.Assists;assembly=Material.Styles"
+             xmlns:assists="clr-namespace:Material.Styles.Assists;assembly=Material.Styles"
              xmlns:system="clr-namespace:System;assembly=System.Runtime"
              xmlns:generic="using:System.Collections.Generic"
              xmlns:sys="clr-namespace:System;assembly=mscorlib"
@@ -46,7 +46,7 @@
             </ComboBox>
           </showMeTheXaml:XamlDisplay>
           <showMeTheXaml:XamlDisplay UniqueId="ComboBoxes3">
-            <ComboBox Theme="{StaticResource MaterialOutlineComboBox}" assist:ComboBoxAssist.Label="ComboBox">
+            <ComboBox Theme="{StaticResource MaterialOutlineComboBox}" assists:ComboBoxAssist.Label="ComboBox">
               <ComboBoxItem>Item 1</ComboBoxItem>
               <ComboBoxItem>Item 2</ComboBoxItem>
               <ComboBoxItem>Item 3</ComboBoxItem>
@@ -54,7 +54,7 @@
             </ComboBox>
           </showMeTheXaml:XamlDisplay>
           <showMeTheXaml:XamlDisplay UniqueId="ComboBoxesDense">
-            <ComboBox Theme="{StaticResource MaterialOutlineComboBox}" assist:ComboBoxAssist.Label="ComboBoxDense"
+            <ComboBox Theme="{StaticResource MaterialOutlineComboBox}" assists:ComboBoxAssist.Label="ComboBoxDense"
                       Classes="dense">
               <ComboBoxItem>Item 1</ComboBoxItem>
               <ComboBoxItem>Item 2</ComboBoxItem>
@@ -100,7 +100,7 @@
             </AutoCompleteBox>
           </showMeTheXaml:XamlDisplay>
           <showMeTheXaml:XamlDisplay UniqueId="AutoCompleteBoxes1">
-            <AutoCompleteBox Watermark="Select a Item">
+            <AutoCompleteBox assists:TextFieldAssist.Label="Countries" assists:AutoCompleteBoxAssist.UseFloatingWatermark="True" Watermark="Select a Item">
               <AutoCompleteBox.ItemsSource>
                 <generic:List x:TypeArguments="x:String">
                   <sys:String>Alabama</sys:String>
@@ -116,7 +116,7 @@
             </AutoCompleteBox>
           </showMeTheXaml:XamlDisplay>
           <showMeTheXaml:XamlDisplay UniqueId="AutoCompleteBoxes2">
-            <AutoCompleteBox Theme="{StaticResource MaterialFilledAutoCompleteBox}" Watermark="Select a Item">
+            <AutoCompleteBox assists:TextFieldAssist.Label="Countries" assists:AutoCompleteBoxAssist.UseFloatingWatermark="True" Theme="{StaticResource MaterialFilledAutoCompleteBox}" Watermark="Select a Item">
               <AutoCompleteBox.ItemsSource>
                 <generic:List x:TypeArguments="x:String">
                   <sys:String>Alabama</sys:String>

--- a/Material.Styles/Assists/AutoCompleteBoxAssist.cs
+++ b/Material.Styles/Assists/AutoCompleteBoxAssist.cs
@@ -1,0 +1,16 @@
+﻿using Avalonia;
+using Avalonia.Controls;
+
+namespace Material.Styles.Assists {
+    public static class AutoCompleteBoxAssist {
+        public static readonly AttachedProperty<bool> UseFloatingWatermarkProperty =
+            AvaloniaProperty.RegisterAttached<AutoCompleteBox, bool>(
+                "UseFloatingWatermark", typeof(AutoCompleteBox), false);
+
+        public static void SetUseFloatingWatermark(AvaloniaObject element, bool value) =>
+            element.SetValue(UseFloatingWatermarkProperty, value);
+
+        public static bool GetUseFloatingWatermark(AvaloniaObject element) =>
+            element.GetValue(UseFloatingWatermarkProperty);
+    }
+}

--- a/Material.Styles/Resources/Themes/AutoCompleteBox.axaml
+++ b/Material.Styles/Resources/Themes/AutoCompleteBox.axaml
@@ -1,11 +1,7 @@
 ﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:assists="clr-namespace:Material.Styles.Assists;assembly=Material.Styles">
   <ControlTheme x:Key="MaterialAutoCompleteBox" TargetType="AutoCompleteBox">
-    <Setter Property="Background" Value="Transparent" />
-    <Setter Property="BorderBrush" Value="{DynamicResource MaterialTextBoxBorderBrush}" />
-    <Setter Property="BorderThickness" Value="0" />
-    <Setter Property="CornerRadius" Value="0" />
-    <Setter Property="Padding" Value="8,6" />
     <Setter Property="Template">
       <ControlTemplate>
         <Panel>
@@ -14,8 +10,12 @@
                    BorderBrush="{TemplateBinding BorderBrush}"
                    BorderThickness="{TemplateBinding BorderThickness}"
                    CornerRadius="{TemplateBinding CornerRadius}"
+                   InnerLeftContent="{TemplateBinding InnerLeftContent}"
+                   InnerRightContent="{TemplateBinding InnerRightContent}"
                    Padding="{TemplateBinding Padding}"
+                   UseFloatingWatermark="{TemplateBinding assists:AutoCompleteBoxAssist.UseFloatingWatermark}"
                    Watermark="{TemplateBinding Watermark}"
+                   assists:TextFieldAssist.Label="{TemplateBinding assists:TextFieldAssist.Label}"
                    DataValidationErrors.Errors="{TemplateBinding (DataValidationErrors.Errors)}" />
 
           <Popup Name="PART_Popup"
@@ -45,39 +45,22 @@
   <ControlTheme x:Key="MaterialFilledAutoCompleteBox"
                 BasedOn="{StaticResource MaterialAutoCompleteBox}"
                 TargetType="AutoCompleteBox">
-    <Setter Property="Background" Value="{DynamicResource MaterialTextFieldBoxBackgroundBrush}" />
     <Setter Property="CornerRadius" Value="4,4,0,0" />
-    <Setter Property="Padding" Value="16,8" />
+
+    <Style Selector="^ /template/ TextBox#PART_TextBox">
+      <Setter Property="Theme" Value="{DynamicResource FilledTextBox}" />
+    </Style>
 
     <Style Selector="^:pointerover">
       <Setter Property="Background" Value="{DynamicResource MaterialTextFieldBoxHoverBackgroundBrush}" />
-    </Style>
-
-    <Style Selector="^:focus-within">
-      <Setter Property="Background" Value="{DynamicResource MaterialTextFieldBoxBackgroundBrush}" />
-      <Setter Property="BorderBrush" Value="{DynamicResource MaterialPrimaryMidBrush}" />
-      <Setter Property="BorderThickness" Value="2" />
     </Style>
   </ControlTheme>
 
   <ControlTheme x:Key="MaterialOutlineAutoCompleteBox"
                 BasedOn="{StaticResource MaterialAutoCompleteBox}"
                 TargetType="AutoCompleteBox">
-    <Setter Property="BorderThickness" Value="1" />
-    <Setter Property="BorderBrush" Value="{DynamicResource MaterialTextBoxBorderBrush}" />
-    <Setter Property="CornerRadius" Value="4" />
-    <Setter Property="Padding" Value="16,8" />
-
-    <Style Selector="^">
-      <Setter Property="BorderThickness" Value="1" />
-    </Style>
-
-    <Style Selector="^:focus-within">
-      <Setter Property="BorderBrush" Value="{DynamicResource MaterialPrimaryMidBrush}" />
-      <Setter Property="BorderThickness" Value="2" />
-      <Style Selector="^ /template/ TextBlock#floatingWatermark">
-        <Setter Property="Foreground" Value="{DynamicResource MaterialPrimaryMidBrush}" />
-      </Style>
+    <Style Selector="^ /template/ TextBox#PART_TextBox">
+      <Setter Property="Theme" Value="{DynamicResource OutlineTextBox}" />
     </Style>
   </ControlTheme>
 </ResourceDictionary>

--- a/Material.Styles/Resources/Themes/AutoCompleteBox.axaml
+++ b/Material.Styles/Resources/Themes/AutoCompleteBox.axaml
@@ -1,11 +1,11 @@
-<ResourceDictionary xmlns="https://github.com/avaloniaui"
+﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
   <ControlTheme x:Key="MaterialAutoCompleteBox" TargetType="AutoCompleteBox">
     <Setter Property="Background" Value="Transparent" />
     <Setter Property="BorderBrush" Value="{DynamicResource MaterialTextBoxBorderBrush}" />
     <Setter Property="BorderThickness" Value="0" />
-    <Setter Property="Padding" Value="4" />
-    <Setter Property="Margin" Value="4" />
+    <Setter Property="CornerRadius" Value="0" />
+    <Setter Property="Padding" Value="8,6" />
     <Setter Property="Template">
       <ControlTemplate>
         <Panel>
@@ -15,7 +15,6 @@
                    BorderThickness="{TemplateBinding BorderThickness}"
                    CornerRadius="{TemplateBinding CornerRadius}"
                    Padding="{TemplateBinding Padding}"
-                   Margin="{TemplateBinding Margin}"
                    Watermark="{TemplateBinding Watermark}"
                    DataValidationErrors.Errors="{TemplateBinding (DataValidationErrors.Errors)}" />
 
@@ -49,6 +48,16 @@
     <Setter Property="Background" Value="{DynamicResource MaterialTextFieldBoxBackgroundBrush}" />
     <Setter Property="CornerRadius" Value="4,4,0,0" />
     <Setter Property="Padding" Value="16,8" />
+
+    <Style Selector="^:pointerover">
+      <Setter Property="Background" Value="{DynamicResource MaterialTextFieldBoxHoverBackgroundBrush}" />
+    </Style>
+
+    <Style Selector="^:focus-within">
+      <Setter Property="Background" Value="{DynamicResource MaterialTextFieldBoxBackgroundBrush}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource MaterialPrimaryMidBrush}" />
+      <Setter Property="BorderThickness" Value="2" />
+    </Style>
   </ControlTheme>
 
   <ControlTheme x:Key="MaterialOutlineAutoCompleteBox"


### PR DESCRIPTION
We added basic styling support in a previous pr https://github.com/AvaloniaCommunity/Material.Avalonia/pull/494 
This pr goes further, taking advantage of the fact that under the hood the AutoCompleteBox is a `TemplatedControl` using a TextBox and for the TextBox we already have great material styling support.

## What this pr provides
- [x] Reuse TextBox styling templates
<img width="188" height="202" alt="image" src="https://github.com/user-attachments/assets/2ddcdf4d-3d73-43d9-8c7d-52bb9e6bca6d" />

- [x] Add support for InnerLeftContent and InnerRightContent
- [x] Add support for Label and UseFloatingWatermark (via assists)

## Limitations 
- Popups are still not properly styled with CornerRadius
- Outline with Label and UseFloatingWatermark does not work properly
<img width="188" height="129" alt="image" src="https://github.com/user-attachments/assets/5dbaea65-4de5-4e1c-9782-a8abf2541753" />