### PR TITLE
Avalonia 12 WindowDrawnDecorations

### DIFF
--- a/Material.Avalonia.Demo/MainWindow.axaml
+++ b/Material.Avalonia.Demo/MainWindow.axaml
@@ -7,6 +7,6 @@
         mc:Ignorable="d" WindowStartupLocation="CenterScreen"
         Width="1280" Height="720" MinWidth="720"
         Icon="/Assets/FavIcon_128x.png"
-        Title="Material.Avalonia Demo" ExtendClientAreaToDecorationsHint="True">
+        Title="Material.Avalonia Demo">
   <demo:MainView />
 </Window>

--- a/Material.Avalonia.Demo/MainWindow.axaml
+++ b/Material.Avalonia.Demo/MainWindow.axaml
@@ -7,6 +7,6 @@
         mc:Ignorable="d" WindowStartupLocation="CenterScreen"
         Width="1280" Height="720" MinWidth="720"
         Icon="/Assets/FavIcon_128x.png"
-        Title="Material.Avalonia Demo">
+        Title="Material.Avalonia Demo" ExtendClientAreaToDecorationsHint="True">
   <demo:MainView />
 </Window>

--- a/Material.Styles/MaterialToolKit.xaml
+++ b/Material.Styles/MaterialToolKit.xaml
@@ -94,6 +94,7 @@
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/TreeView.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/TreeViewItem.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/Window.axaml" />
+        <ResourceInclude Source="avares://Material.Styles/Resources/Themes/WindowDrawnDecorations.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/WindowNotificationManager.axaml" />
       </ResourceDictionary.MergedDictionaries>
     </ResourceDictionary>

--- a/Material.Styles/Resources/Themes/WindowDrawnDecorations.axaml
+++ b/Material.Styles/Resources/Themes/WindowDrawnDecorations.axaml
@@ -1,0 +1,195 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+  <x:Double x:Key="CaptionButtonWidth">45</x:Double>
+  <x:Double x:Key="CaptionButtonHeight">30</x:Double>
+
+  <ControlTheme x:Key="MaterialDrawnCaptionButton" TargetType="Button">
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="BorderBrush" Value="Transparent" />
+    <Setter Property="Foreground" Value="{DynamicResource MaterialBodyBrush}" />
+    <Setter Property="Width" Value="{DynamicResource CaptionButtonWidth}" />
+    <Setter Property="Height" Value="{DynamicResource CaptionButtonHeight}" />
+    <Setter Property="VerticalAlignment" Value="Stretch" />
+    <Setter Property="(WindowDecorationProperties.ElementRole)" Value="DecorationsElement" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <ContentPresenter Name="PART_ContentPresenter"
+                          Background="Transparent"
+                          Content="{TemplateBinding Content}" />
+      </ControlTemplate>
+    </Setter>
+    <Style Selector="^:pointerover /template/ ContentPresenter">
+      <Setter Property="Background" Value="{TemplateBinding Background}" />
+    </Style>
+    <Style Selector="^:pressed /template/ ContentPresenter">
+      <Setter Property="Background" Value="{TemplateBinding BorderBrush}" />
+    </Style>
+  </ControlTheme>
+
+  <ControlTheme x:Key="{x:Type WindowDrawnDecorations}" TargetType="WindowDrawnDecorations">
+    <Setter Property="DefaultTitleBarHeight" Value="30" />
+    <Setter Property="DefaultFrameThickness" Value="1" />
+    <Setter Property="DefaultShadowThickness" Value="8" />
+    <Setter Property="Template">
+      <WindowDrawnDecorationsTemplate>
+        <WindowDrawnDecorationsContent>
+          <WindowDrawnDecorationsContent.Underlay>
+            <Panel x:Name="PART_UnderlayWrapper">
+              <Border x:Name="PART_WindowBorder"
+                      Background="{DynamicResource MaterialPaperBrush}"
+                      BorderThickness="{TemplateBinding FrameThickness}"
+                      BorderBrush="{DynamicResource MaterialDividerBrush}"
+                      IsHitTestVisible="False" />
+              <Panel x:Name="PART_TitleBar" VerticalAlignment="Top"
+                     Height="{TemplateBinding TitleBarHeight}"
+                     Background="{DynamicResource MaterialPaperBrush}"
+                     IsVisible="{TemplateBinding HasTitleBar}"
+                     WindowDecorationProperties.ElementRole="TitleBar" />
+            </Panel>
+          </WindowDrawnDecorationsContent.Underlay>
+          <WindowDrawnDecorationsContent.Overlay>
+            <Panel x:Name="PART_OverlayWrapper">
+              <Panel x:Name="PART_TitleTextPanel" VerticalAlignment="Top"
+                     Height="{TemplateBinding TitleBarHeight}"
+                     IsHitTestVisible="False"
+                     IsVisible="{TemplateBinding HasTitleBar}">
+                <TextBlock Text="{TemplateBinding Title}"
+                           VerticalAlignment="Center"
+                           Margin="12,0,0,0"
+                           FontSize="12" />
+              </Panel>
+              <StackPanel x:Name="PART_OverlayPanel"
+                          VerticalAlignment="Top"
+                          HorizontalAlignment="Right"
+                          Height="{TemplateBinding TitleBarHeight}"
+                          IsVisible="{TemplateBinding HasTitleBar}"
+                          Orientation="Horizontal"
+                          Spacing="2"
+                          TextElement.FontSize="10">
+                <Button x:Name="PART_FullScreenButton"
+                        Theme="{StaticResource MaterialDrawnCaptionButton}"
+                        WindowDecorationProperties.ElementRole="FullScreenButton">
+                  <Viewbox Width="11" Margin="2">
+                    <Path Name="FullScreenButtonPath" Stretch="UniformToFill"
+                          Fill="{DynamicResource MaterialBodyBrush}"
+                          Data="M2048 2048v-819h-205v469l-1493 -1493h469v-205h-819v819h205v-469l1493 1493h-469v205h819z" />
+                  </Viewbox>
+                </Button>
+                <Button x:Name="PART_MinimizeButton"
+                        Theme="{StaticResource MaterialDrawnCaptionButton}"
+                        WindowDecorationProperties.ElementRole="MinimizeButton">
+                  <Viewbox Width="11" Margin="2">
+                    <Path Stretch="UniformToFill"
+                          Fill="{DynamicResource MaterialBodyBrush}"
+                          Data="M2048 1229v-205h-2048v205h2048z" />
+                  </Viewbox>
+                </Button>
+                <Button x:Name="PART_MaximizeButton"
+                        Theme="{StaticResource MaterialDrawnCaptionButton}"
+                        WindowDecorationProperties.ElementRole="MaximizeButton">
+                  <Viewbox Width="11" Margin="2">
+                    <Viewbox.RenderTransform>
+                      <RotateTransform Angle="-90" />
+                    </Viewbox.RenderTransform>
+                    <Path Name="RestoreButtonPath" Stretch="UniformToFill"
+                          Fill="{DynamicResource MaterialBodyBrush}"
+                          Data="M2048 2048v-2048h-2048v2048h2048zM1843 1843h-1638v-1638h1638v1638z" />
+                  </Viewbox>
+                </Button>
+                <Button x:Name="PART_CloseButton"
+                        Background="#ffe81123" BorderBrush="#fff1707a"
+                        Theme="{StaticResource MaterialDrawnCaptionButton}"
+                        WindowDecorationProperties.ElementRole="CloseButton">
+                  <Viewbox Width="11" Margin="2">
+                    <Path Stretch="UniformToFill"
+                          Fill="{DynamicResource MaterialBodyBrush}"
+                          Data="M1169 1024l879 -879l-145 -145l-879 879l-879 -879l-145 145l879 879l-879 879l145 145l879 -879l879 879l145 -145z" />
+                  </Viewbox>
+                </Button>
+              </StackPanel>
+            </Panel>
+          </WindowDrawnDecorationsContent.Overlay>
+          <WindowDrawnDecorationsContent.FullscreenPopover>
+            <Panel Height="{TemplateBinding DefaultTitleBarHeight}"
+                   VerticalAlignment="Top"
+                   Background="{DynamicResource MaterialPaperBrush}"
+                   WindowDecorationProperties.ElementRole="TitleBar">
+              <TextBlock Text="{TemplateBinding Title}"
+                         VerticalAlignment="Center"
+                         Margin="12,0,0,0" FontSize="12" />
+              <StackPanel HorizontalAlignment="Right"
+                          Orientation="Horizontal" Spacing="2"
+                          TextElement.FontSize="10">
+                <Button x:Name="PART_PopoverFullScreenButton"
+                        Theme="{StaticResource MaterialDrawnCaptionButton}"
+                        WindowDecorationProperties.ElementRole="FullScreenButton">
+                  <Viewbox Width="11" Margin="2">
+                    <Path Stretch="UniformToFill"
+                          Fill="{DynamicResource MaterialBodyBrush}"
+                          Data="M205 1024h819v-819h-205v469l-674 -674l-145 145l674 674h-469v205zM1374 1229h469v-205h-819v819h205v-469l674 674l145 -145z" />
+                  </Viewbox>
+                </Button>
+                <Button x:Name="PART_PopoverCloseButton"
+                        Background="#ffe81123" BorderBrush="#fff1707a"
+                        Theme="{StaticResource MaterialDrawnCaptionButton}"
+                        WindowDecorationProperties.ElementRole="CloseButton">
+                  <Viewbox Width="11" Margin="2">
+                    <Path Stretch="UniformToFill"
+                          Fill="{DynamicResource MaterialBodyBrush}"
+                          Data="M1169 1024l879 -879l-145 -145l-879 879l-879 -879l-145 145l879 879l-879 879l145 145l879 -879l879 879l145 -145z" />
+                  </Viewbox>
+                </Button>
+              </StackPanel>
+            </Panel>
+          </WindowDrawnDecorationsContent.FullscreenPopover>
+        </WindowDrawnDecorationsContent>
+      </WindowDrawnDecorationsTemplate>
+    </Setter>
+    <Style Selector="^:has-shadow /template/ Panel#PART_UnderlayWrapper">
+      <Setter Property="Margin" Value="{TemplateBinding ShadowThickness}" />
+    </Style>
+    <Style Selector="^:has-shadow /template/ Border#PART_WindowBorder">
+      <Setter Property="BoxShadow" Value="0 2 10 2 #80000000" />
+    </Style>
+    <Style Selector="^:has-shadow /template/ Panel#PART_OverlayWrapper">
+      <Setter Property="Margin" Value="{TemplateBinding ShadowThickness}" />
+    </Style>
+    <Style Selector="^:has-border /template/ Panel#PART_TitleTextPanel">
+      <Setter Property="Margin" Value="1,1,1,0" />
+    </Style>
+    <Style Selector="^:has-border /template/ Panel#PART_TitleBar">
+      <Setter Property="Margin" Value="1,1,1,0" />
+    </Style>
+    <Style Selector="^:has-border /template/ StackPanel#PART_OverlayPanel">
+      <Setter Property="Margin" Value="0,1,1,0" />
+    </Style>
+    <Style Selector="^:maximized /template/ Path#RestoreButtonPath">
+      <Setter Property="Data" Value="M2048 410h-410v-410h-1638v1638h410v410h1638v-1638zM1434 1434h-1229v-1229h1229v1229zM1843 1843h-1229v-205h1024v-1024h205v1229z" />
+    </Style>
+    <Style Selector="^ /template/ Button:disabled">
+      <Setter Property="Opacity" Value="0.2" />
+    </Style>
+    <Style Selector="^:not(:has-minimize) /template/ Button#PART_MinimizeButton">
+      <Setter Property="IsVisible" Value="False" />
+    </Style>
+    <Style Selector="^:not(:has-maximize) /template/ Button#PART_MaximizeButton">
+      <Setter Property="IsVisible" Value="False" />
+    </Style>
+    <Style Selector="^:not(:has-fullscreen) /template/ Button#PART_FullScreenButton">
+      <Setter Property="IsVisible" Value="False" />
+    </Style>
+    <Style Selector="^:not(:has-fullscreen) /template/ Button#PART_PopoverFullScreenButton">
+      <Setter Property="IsVisible" Value="False" />
+    </Style>
+    <Style Selector="^:fullscreen /template/ Panel#PART_TitleTextPanel">
+      <Setter Property="IsVisible" Value="False" />
+    </Style>
+    <Style Selector="^:fullscreen /template/ StackPanel#PART_OverlayPanel">
+      <Setter Property="IsVisible" Value="False" />
+    </Style>
+    <Style Selector="^:fullscreen /template/ Panel#PART_TitleBar">
+      <Setter Property="IsVisible" Value="False" />
+    </Style>
+  </ControlTheme>
+</ResourceDictionary>


### PR DESCRIPTION
All my Material.Avalonia apps have 

`ExtendClientAreaToDecorationsHint="true"`

Since the new avalonia 12 windowdecoration changes my apps did not show any windowdecoration buttons at all, also the window was not draggable.

I added the new windowdecorations theme based on material. based on https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Themes.Fluent/Controls/WindowDrawnDecorations.xaml

This is my first  PR though. so I dont know if I am doing everything correct.

#503 