### PR TITLE
Avalonia12 pipspager and carouseldemo

### DIFF
--- a/Material.Avalonia.Demo/MainView.axaml
+++ b/Material.Avalonia.Demo/MainView.axaml
@@ -65,6 +65,7 @@
                 <ListBoxItem>Home</ListBoxItem>
                 <ListBoxItem>Badges</ListBoxItem>
                 <ListBoxItem>Buttons</ListBoxItem>
+                <ListBoxItem>Carousel</ListBoxItem>
                 <ListBoxItem>Card</ListBoxItem>
                 <ListBoxItem>ColorZones</ListBoxItem>
                 <ListBoxItem>Colors</ListBoxItem>
@@ -161,7 +162,10 @@
 
                 <!-- Buttons -->
                 <pages:ButtonsDemo />
-                
+
+                <!-- Carousel -->
+                <pages:CarouselDemo />
+
                 <!-- Card -->
                 <pages:CardsDemo />
                 

--- a/Material.Avalonia.Demo/Pages/CarouselDemo.axaml
+++ b/Material.Avalonia.Demo/Pages/CarouselDemo.axaml
@@ -1,0 +1,252 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:avalonia="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
+             xmlns:controls="clr-namespace:Material.Styles.Controls;assembly=Material.Styles"
+             xmlns:assists="clr-namespace:Material.Styles.Assists;assembly=Material.Styles"
+             xmlns:showMeTheXaml="clr-namespace:ShowMeTheXaml;assembly=ShowMeTheXaml.Avalonia"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="Material.Avalonia.Demo.Pages.CarouselDemo">
+  <StackPanel Margin="16, 0">
+    <TextBlock Classes="Headline4 Subheadline" Text="Carousel" />
+    <TextBlock Classes="Body1 Content" Text="A carousel with PipsPager navigation control." />
+
+    <WrapPanel Orientation="Horizontal" ItemSpacing="30" LineSpacing="30">
+
+      <!-- Basic Carousel with PipsPager -->
+      <StackPanel MaxWidth="500">
+        <TextBlock Classes="Headline6 Subheadline2" Text="Basic (Dot Shape)" />
+        <showMeTheXaml:XamlDisplay UniqueId="CarouselBasic">
+          <controls:Card Padding="0">
+            <DockPanel>
+              <PipsPager Name="PipsPager"
+                         DockPanel.Dock="Bottom"
+                         HorizontalAlignment="Center"
+                         Margin="0,8"
+                         NumberOfPages="4"
+                         SelectedPageIndex="0"
+                         assists:PipsPagerAssist.PipShape="Dot" />
+              <Carousel Name="DemoCarousel"
+                        SelectedIndex="{Binding #PipsPager.SelectedPageIndex}"
+                        Height="200">
+                <Carousel.PageTransition>
+                  <PageSlide Duration="0:0:0.3" SlideOutEasing="CubicEaseOut" SlideInEasing="CubicEaseOut" />
+                </Carousel.PageTransition>
+                <Border Background="{DynamicResource MaterialPrimaryLightBrush}">
+                  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center">
+                    <avalonia:MaterialIcon Kind="Image" Width="48" Height="48" Foreground="{DynamicResource MaterialPrimaryLightForegroundBrush}" />
+                    <TextBlock Classes="Headline6" Text="Page 1" Foreground="{DynamicResource MaterialPrimaryLightForegroundBrush}" HorizontalAlignment="Center" Margin="0,8,0,0" />
+                  </StackPanel>
+                </Border>
+                <Border Background="{DynamicResource MaterialSecondaryMidBrush}">
+                  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center">
+                    <avalonia:MaterialIcon Kind="Star" Width="48" Height="48" Foreground="{DynamicResource MaterialSecondaryMidForegroundBrush}" />
+                    <TextBlock Classes="Headline6" Text="Page 2" Foreground="{DynamicResource MaterialSecondaryMidForegroundBrush}" HorizontalAlignment="Center" Margin="0,8,0,0" />
+                  </StackPanel>
+                </Border>
+                <Border Background="{DynamicResource MaterialPrimaryMidBrush}">
+                  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center">
+                    <avalonia:MaterialIcon Kind="Heart" Width="48" Height="48" Foreground="{DynamicResource MaterialPrimaryMidForegroundBrush}" />
+                    <TextBlock Classes="Headline6" Text="Page 3" Foreground="{DynamicResource MaterialPrimaryMidForegroundBrush}" HorizontalAlignment="Center" Margin="0,8,0,0" />
+                  </StackPanel>
+                </Border>
+                <Border Background="{DynamicResource MaterialSecondaryLightBrush}">
+                  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center">
+                    <avalonia:MaterialIcon Kind="Check" Width="48" Height="48" Foreground="{DynamicResource MaterialSecondaryLightForegroundBrush}" />
+                    <TextBlock Classes="Headline6" Text="Page 4" Foreground="{DynamicResource MaterialSecondaryLightForegroundBrush}" HorizontalAlignment="Center" Margin="0,8,0,0" />
+                  </StackPanel>
+                </Border>
+              </Carousel>
+            </DockPanel>
+          </controls:Card>
+        </showMeTheXaml:XamlDisplay>
+      </StackPanel>
+
+      <!-- Pill Shape -->
+      <StackPanel  MaxWidth="500">
+        <TextBlock Classes="Headline6 Subheadline2" Text="Pill Shape" />
+        <showMeTheXaml:XamlDisplay UniqueId="CarouselPill">
+          <controls:Card Padding="0">
+            <DockPanel>
+              <PipsPager Name="PillPipsPager"
+                         DockPanel.Dock="Bottom"
+                         HorizontalAlignment="Center"
+                         Margin="0,8"
+                         NumberOfPages="4"
+                         SelectedPageIndex="0"
+                         assists:PipsPagerAssist.PipShape="Pill" />
+              <Carousel SelectedIndex="{Binding #PillPipsPager.SelectedPageIndex}" Height="200">
+                <Carousel.PageTransition>
+                  <PageSlide Duration="0:0:0.3" SlideOutEasing="CubicEaseOut" SlideInEasing="CubicEaseOut" />
+                </Carousel.PageTransition>
+                <Border Background="{DynamicResource MaterialPrimaryLightBrush}">
+                  <TextBlock Classes="Headline6" Text="Slide 1" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="{DynamicResource MaterialPrimaryLightForegroundBrush}" />
+                </Border>
+                <Border Background="{DynamicResource MaterialSecondaryMidBrush}">
+                  <TextBlock Classes="Headline6" Text="Slide 2" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="{DynamicResource MaterialSecondaryMidForegroundBrush}" />
+                </Border>
+                <Border Background="{DynamicResource MaterialPrimaryMidBrush}">
+                  <TextBlock Classes="Headline6" Text="Slide 3" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="{DynamicResource MaterialPrimaryMidForegroundBrush}" />
+                </Border>
+                <Border Background="{DynamicResource MaterialPrimaryDarkBrush}">
+                  <TextBlock Classes="Headline6" Text="Slide 4" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="{DynamicResource MaterialPrimaryDarkForegroundBrush}" />
+                </Border>
+              </Carousel>
+            </DockPanel>
+          </controls:Card>
+        </showMeTheXaml:XamlDisplay>
+      </StackPanel>
+
+      <!-- Custom Pip Colors -->
+      <StackPanel MaxWidth="500">
+        <TextBlock Classes="Headline6 Subheadline2" Text="Custom Pip Colors" />
+        <showMeTheXaml:XamlDisplay UniqueId="CarouselCustomColors">
+          <controls:Card Padding="0">
+            <DockPanel>
+              <PipsPager Name="CustomColorPipsPager"
+                         DockPanel.Dock="Bottom"
+                         HorizontalAlignment="Center"
+                         Margin="0,8"
+                         NumberOfPages="4"
+                         SelectedPageIndex="0">
+                <PipsPager.Resources>
+                  <SolidColorBrush x:Key="MaterialBodyBrush" Color="Gold" />
+                  <SolidColorBrush x:Key="MaterialPrimaryMidBrush" Color="Cyan" />
+                </PipsPager.Resources>
+              </PipsPager>
+              <Carousel SelectedIndex="{Binding #CustomColorPipsPager.SelectedPageIndex}" Height="200">
+                <Carousel.PageTransition>
+                  <PageSlide Duration="0:0:0.3" SlideOutEasing="CubicEaseOut" SlideInEasing="CubicEaseOut" />
+                </Carousel.PageTransition>
+                <Border Background="#FCE4EC">
+                  <TextBlock Classes="Headline6" Text="Pink Light" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="#880E4F" />
+                </Border>
+                <Border Background="#F8BBD0">
+                  <TextBlock Classes="Headline6" Text="Pink 100" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="#880E4F" />
+                </Border>
+                <Border Background="#F48FB1">
+                  <TextBlock Classes="Headline6" Text="Pink 200" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="#FFFFFF" />
+                </Border>
+                <Border Background="#E91E63">
+                  <TextBlock Classes="Headline6" Text="Pink 500" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="#FFFFFF" />
+                </Border>
+              </Carousel>
+            </DockPanel>
+          </controls:Card>
+        </showMeTheXaml:XamlDisplay>
+      </StackPanel>
+
+      <!-- Numbered Pips -->
+      <StackPanel MaxWidth="500">
+        <TextBlock Classes="Headline6 Subheadline2" Text="Numbers" />
+        <showMeTheXaml:XamlDisplay UniqueId="CarouselNumbers">
+          <controls:Card Padding="0">
+            <DockPanel>
+              <PipsPager Name="NumberPipsPager"
+                         DockPanel.Dock="Bottom"
+                         HorizontalAlignment="Center"
+                         Margin="0,8"
+                         NumberOfPages="4"
+                         SelectedPageIndex="0"
+                         assists:PipsPagerAssist.PipShape="Number" />
+              <Carousel SelectedIndex="{Binding #NumberPipsPager.SelectedPageIndex}" Height="200">
+                <Carousel.PageTransition>
+                  <PageSlide Duration="0:0:0.3" SlideOutEasing="CubicEaseOut" SlideInEasing="CubicEaseOut" />
+                </Carousel.PageTransition>
+                <Border Background="#E3F2FD">
+                  <TextBlock Classes="Headline6" Text="Page 1" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="#1565C0" />
+                </Border>
+                <Border Background="#E8F5E9">
+                  <TextBlock Classes="Headline6" Text="Page 2" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="#2E7D32" />
+                </Border>
+                <Border Background="#FFF3E0">
+                  <TextBlock Classes="Headline6" Text="Page 3" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="#E65100" />
+                </Border>
+                <Border Background="#F3E5F5">
+                  <TextBlock Classes="Headline6" Text="Page 4" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="#6A1B9A" />
+                </Border>
+              </Carousel>
+            </DockPanel>
+          </controls:Card>
+        </showMeTheXaml:XamlDisplay>
+      </StackPanel>
+
+      <!-- Large Collection with Auto-Scrolling Pips -->
+      <StackPanel MaxWidth="500">
+        <TextBlock Classes="Headline6 Subheadline2" Text="Auto-Scrolling Pips (MaxVisiblePips)" />
+        <showMeTheXaml:XamlDisplay UniqueId="CarouselLarge">
+          <controls:Card Padding="0">
+            <DockPanel>
+              <PipsPager Name="LargePipsPager"
+                         DockPanel.Dock="Bottom"
+                         HorizontalAlignment="Center"
+                         Margin="0,8"
+                         NumberOfPages="10"
+                         MaxVisiblePips="5"
+                         SelectedPageIndex="0" />
+              <Carousel SelectedIndex="{Binding #LargePipsPager.SelectedPageIndex}" Height="200">
+                <Carousel.PageTransition>
+                  <PageSlide Duration="0:0:0.3" SlideOutEasing="CubicEaseOut" SlideInEasing="CubicEaseOut" />
+                </Carousel.PageTransition>
+                <Border Background="#E91E63"><TextBlock Classes="Headline5" Text="1 of 10" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White" /></Border>
+                <Border Background="#9C27B0"><TextBlock Classes="Headline5" Text="2 of 10" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White" /></Border>
+                <Border Background="#673AB7"><TextBlock Classes="Headline5" Text="3 of 10" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White" /></Border>
+                <Border Background="#3F51B5"><TextBlock Classes="Headline5" Text="4 of 10" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White" /></Border>
+                <Border Background="#2196F3"><TextBlock Classes="Headline5" Text="5 of 10" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White" /></Border>
+                <Border Background="#009688"><TextBlock Classes="Headline5" Text="6 of 10" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White" /></Border>
+                <Border Background="#4CAF50"><TextBlock Classes="Headline5" Text="7 of 10" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White" /></Border>
+                <Border Background="#FF9800"><TextBlock Classes="Headline5" Text="8 of 10" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White" /></Border>
+                <Border Background="#FF5722"><TextBlock Classes="Headline5" Text="9 of 10" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White" /></Border>
+                <Border Background="#795548"><TextBlock Classes="Headline5" Text="10 of 10" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White" /></Border>
+              </Carousel>
+            </DockPanel>
+          </controls:Card>
+        </showMeTheXaml:XamlDisplay>
+      </StackPanel>
+
+      <!-- Vertical Orientation -->
+      <StackPanel MaxWidth="500">
+        <TextBlock Classes="Headline6 Subheadline2" Text="Vertical Orientation" />
+        <showMeTheXaml:XamlDisplay UniqueId="CarouselVertical">
+          <controls:Card Padding="0">
+            <StackPanel Orientation="Horizontal">
+              <Carousel Name="VerticalCarousel"
+                        SelectedIndex="{Binding #VerticalPipsPager.SelectedPageIndex}"
+                        Height="250" Width="400">
+                <Carousel.PageTransition>
+                  <PageSlide Duration="0:0:0.3" Orientation="Vertical" SlideOutEasing="CubicEaseOut" SlideInEasing="CubicEaseOut" />
+                </Carousel.PageTransition>
+                <Border Background="{DynamicResource MaterialPrimaryLightBrush}">
+                  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center">
+                    <avalonia:MaterialIcon Kind="ArrowUp" Width="48" Height="48" Foreground="{DynamicResource MaterialPrimaryLightForegroundBrush}" />
+                    <TextBlock Classes="Headline6" Text="Top" Foreground="{DynamicResource MaterialPrimaryLightForegroundBrush}" HorizontalAlignment="Center" Margin="0,8,0,0" />
+                  </StackPanel>
+                </Border>
+                <Border Background="{DynamicResource MaterialSecondaryMidBrush}">
+                  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center">
+                    <avalonia:MaterialIcon Kind="DotsHorizontal" Width="48" Height="48" Foreground="{DynamicResource MaterialSecondaryMidForegroundBrush}" />
+                    <TextBlock Classes="Headline6" Text="Middle" Foreground="{DynamicResource MaterialSecondaryMidForegroundBrush}" HorizontalAlignment="Center" Margin="0,8,0,0" />
+                  </StackPanel>
+                </Border>
+                <Border Background="{DynamicResource MaterialPrimaryDarkBrush}">
+                  <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center">
+                    <avalonia:MaterialIcon Kind="ArrowDown" Width="48" Height="48" Foreground="{DynamicResource MaterialPrimaryDarkForegroundBrush}" />
+                    <TextBlock Classes="Headline6" Text="Bottom" Foreground="{DynamicResource MaterialPrimaryDarkForegroundBrush}" HorizontalAlignment="Center" Margin="0,8,0,0" />
+                  </StackPanel>
+                </Border>
+              </Carousel>
+              <PipsPager Name="VerticalPipsPager"
+                         Orientation="Vertical"
+                         VerticalAlignment="Center"
+                         Margin="8,0"
+                         NumberOfPages="3"
+                         SelectedPageIndex="0" />
+            </StackPanel>
+          </controls:Card>
+        </showMeTheXaml:XamlDisplay>
+      </StackPanel>
+
+    </WrapPanel>
+  </StackPanel>
+</UserControl>

--- a/Material.Avalonia.Demo/Pages/CarouselDemo.axaml.cs
+++ b/Material.Avalonia.Demo/Pages/CarouselDemo.axaml.cs
@@ -1,0 +1,9 @@
+using Avalonia.Controls;
+
+namespace Material.Avalonia.Demo.Pages;
+
+public partial class CarouselDemo : UserControl {
+    public CarouselDemo() {
+        InitializeComponent();
+    }
+}

--- a/Material.Styles/Assists/PipsPagerAssist.cs
+++ b/Material.Styles/Assists/PipsPagerAssist.cs
@@ -1,0 +1,52 @@
+using System;
+using Avalonia;
+using Avalonia.Controls;
+
+namespace Material.Styles.Assists
+{
+    public enum PipShape
+    {
+        Dot,
+        Pill,
+        Number
+    }
+
+    public static class PipsPagerAssist
+    {
+        #region AttachedProperty : PipShape
+
+        public static readonly AttachedProperty<PipShape> PipShapeProperty =
+            AvaloniaProperty.RegisterAttached<PipsPager, PipShape>("PipShape", typeof(PipsPagerAssist), PipShape.Dot);
+
+        public static void SetPipShape(AvaloniaObject element, PipShape value) =>
+            element.SetValue(PipShapeProperty, value);
+
+        public static PipShape GetPipShape(AvaloniaObject element) =>
+            element.GetValue(PipShapeProperty);
+
+        #endregion
+
+        static PipsPagerAssist()
+        {
+            PipShapeProperty.Changed.AddClassHandler<PipsPager>((pager, args) =>
+            {
+                pager.Classes.Remove("pip-dot");
+                pager.Classes.Remove("pip-pill");
+                pager.Classes.Remove("pip-number");
+
+                switch (args.GetNewValue<PipShape>())
+                {
+                    case PipShape.Dot:
+                        pager.Classes.Add("pip-dot");
+                        break;
+                    case PipShape.Pill:
+                        pager.Classes.Add("pip-pill");
+                        break;
+                    case PipShape.Number:
+                        pager.Classes.Add("pip-number");
+                        break;
+                }
+            });
+        }
+    }
+}

--- a/Material.Styles/Assists/PipsPagerAssist.cs
+++ b/Material.Styles/Assists/PipsPagerAssist.cs
@@ -1,20 +1,11 @@
-using System;
 using Avalonia;
 using Avalonia.Controls;
+using Material.Styles.Enums;
 
 namespace Material.Styles.Assists
 {
-    public enum PipShape
-    {
-        Dot,
-        Pill,
-        Number
-    }
-
     public static class PipsPagerAssist
     {
-        #region AttachedProperty : PipShape
-
         public static readonly AttachedProperty<PipShape> PipShapeProperty =
             AvaloniaProperty.RegisterAttached<PipsPager, PipShape>("PipShape", typeof(PipsPagerAssist), PipShape.Dot);
 
@@ -24,28 +15,12 @@ namespace Material.Styles.Assists
         public static PipShape GetPipShape(AvaloniaObject element) =>
             element.GetValue(PipShapeProperty);
 
-        #endregion
-
-        static PipsPagerAssist()
-        {
-            PipShapeProperty.Changed.AddClassHandler<PipsPager>((pager, args) =>
-            {
-                pager.Classes.Remove("pip-dot");
-                pager.Classes.Remove("pip-pill");
-                pager.Classes.Remove("pip-number");
-
-                switch (args.GetNewValue<PipShape>())
-                {
-                    case PipShape.Dot:
-                        pager.Classes.Add("pip-dot");
-                        break;
-                    case PipShape.Pill:
-                        pager.Classes.Add("pip-pill");
-                        break;
-                    case PipShape.Number:
-                        pager.Classes.Add("pip-number");
-                        break;
-                }
+        static PipsPagerAssist() {
+            PipShapeProperty.Changed.AddClassHandler<PipsPager>((pager, args) => {
+                var newValue = args.GetNewValue<PipShape>();
+                pager.Classes.Set("pip-dot", newValue == PipShape.Dot);
+                pager.Classes.Set("pip-pill", newValue == PipShape.Pill);
+                pager.Classes.Set("pip-number", newValue == PipShape.Number);
             });
         }
     }

--- a/Material.Styles/Enums/PipShape.cs
+++ b/Material.Styles/Enums/PipShape.cs
@@ -1,0 +1,7 @@
+﻿namespace Material.Styles.Enums;
+
+public enum PipShape {
+    Dot,
+    Pill,
+    Number
+}

--- a/Material.Styles/MaterialToolKit.xaml
+++ b/Material.Styles/MaterialToolKit.xaml
@@ -66,6 +66,7 @@
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/NumericUpDown.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/OverlayPopupHost.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/PathIcon.xaml" />
+        <ResourceInclude Source="avares://Material.Styles/Resources/Themes/PipsPager.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/PopupRoot.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/ProgressBar.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/RadioButton.axaml" />

--- a/Material.Styles/Resources/Themes/PipsPager.axaml
+++ b/Material.Styles/Resources/Themes/PipsPager.axaml
@@ -63,7 +63,7 @@
                 <Setter Property="VerticalAlignment" Value="Center" />
                 <Setter Property="Template">
                   <ControlTemplate>
-                    <Panel Background="Transparent"
+                    <Panel Background="Transparent"  Cursor="Hand"
                            HorizontalAlignment="Center"
                            VerticalAlignment="Center">
                       <Border Name="Pip"

--- a/Material.Styles/Resources/Themes/PipsPager.axaml
+++ b/Material.Styles/Resources/Themes/PipsPager.axaml
@@ -1,0 +1,221 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:converters="clr-namespace:Material.Styles.Converters">
+
+  <ControlTheme x:Key="MaterialPipsPager" TargetType="PipsPager">
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="IsTabStop" Value="False" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <StackPanel Name="PART_RootPanel"
+                    Orientation="{TemplateBinding Orientation}"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    ClipToBounds="False">
+
+          <Button Name="PART_PreviousButton"
+                  Theme="{StaticResource MaterialFlatButton}"
+                  Width="32"
+                  Height="32"
+                  Padding="0"
+                  HorizontalContentAlignment="Center"
+                  VerticalContentAlignment="Center"
+                  IsVisible="{TemplateBinding IsPreviousButtonVisible}"
+                  VerticalAlignment="Center"
+                  HorizontalAlignment="Center"
+                  Margin="4">
+            <PathIcon Width="12" Height="12"
+                      Data="M15.41,16.58L10.83,12L15.41,7.41L14,6L8,12L14,18L15.41,16.58Z" />
+          </Button>
+
+          <ListBox Name="PART_PipsPagerList"
+                   Background="Transparent"
+                   BorderThickness="0"
+                   Padding="0"
+                   HorizontalAlignment="Center"
+                   VerticalAlignment="Center"
+                   ScrollViewer.HorizontalScrollBarVisibility="Hidden"
+                   ScrollViewer.VerticalScrollBarVisibility="Hidden"
+                   ItemsSource="{Binding TemplateSettings.Pips, RelativeSource={RelativeSource TemplatedParent}}"
+                   SelectedIndex="{Binding SelectedPageIndex, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}"
+                   AutoScrollToSelectedItem="False"
+                   ClipToBounds="False">
+            <ListBox.ItemsPanel>
+              <ItemsPanelTemplate>
+                <StackPanel Orientation="{Binding Orientation, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=PipsPager}}"
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center"
+                            Spacing="4" />
+              </ItemsPanelTemplate>
+            </ListBox.ItemsPanel>
+            <ListBox.Styles>
+              <Style Selector="ScrollViewer">
+                <Setter Property="ClipToBounds" Value="False" />
+              </Style>
+              <Style Selector="ListBoxItem">
+                <Setter Property="Width" Value="12" />
+                <Setter Property="Height" Value="24" />
+                <Setter Property="Padding" Value="0" />
+                <Setter Property="Margin" Value="2,0" />
+                <Setter Property="MinHeight" Value="0" />
+                <Setter Property="MinWidth" Value="0" />
+                <Setter Property="ClipToBounds" Value="False" />
+                <Setter Property="VerticalAlignment" Value="Center" />
+                <Setter Property="Template">
+                  <ControlTemplate>
+                    <Panel Background="Transparent"
+                           HorizontalAlignment="Center"
+                           VerticalAlignment="Center">
+                      <Border Name="Pip"
+                              Width="8" Height="8"
+                              CornerRadius="4"
+                              Background="{DynamicResource MaterialBodyBrush}"
+                              Opacity="0.38">
+                        <TextBlock Name="PipNumber"
+                                   IsVisible="False"
+                                   Text="{Binding DataType=x:Int32}"
+                                   FontSize="11"
+                                   FontWeight="Medium"
+                                   Foreground="{DynamicResource MaterialPaperBrush}"
+                                   HorizontalAlignment="Center"
+                                   VerticalAlignment="Center" />
+                        <Border.Transitions>
+                          <Transitions>
+                            <BrushTransition Property="Background" Duration="0:0:0.25" />
+                            <DoubleTransition Property="Opacity" Duration="0:0:0.25" />
+                            <DoubleTransition Property="Width" Duration="0:0:0.25" Easing="CubicEaseOut" />
+                            <DoubleTransition Property="Height" Duration="0:0:0.25" Easing="CubicEaseOut" />
+                            <CornerRadiusTransition Property="CornerRadius" Duration="0:0:0.25" />
+                          </Transitions>
+                        </Border.Transitions>
+                      </Border>
+                    </Panel>
+                  </ControlTemplate>
+                </Setter>
+              </Style>
+              <Style Selector="ListBoxItem:pointerover /template/ Border#Pip">
+                <Setter Property="Background" Value="{DynamicResource MaterialPrimaryMidBrush}" />
+                <Setter Property="Opacity" Value="0.6" />
+              </Style>
+              <Style Selector="ListBoxItem:selected /template/ Border#Pip">
+                <Setter Property="Background" Value="{DynamicResource MaterialPrimaryMidBrush}" />
+                <Setter Property="Opacity" Value="1" />
+              </Style>
+              <Style Selector="ListBoxItem:selected:pointerover /template/ Border#Pip">
+                <Setter Property="Background" Value="{DynamicResource MaterialPrimaryMidBrush}" />
+                <Setter Property="Opacity" Value="0.85" />
+              </Style>
+              <Style Selector="PipsPager:vertical ListBoxItem">
+                <Setter Property="Width" Value="24" />
+                <Setter Property="Height" Value="12" />
+                <Setter Property="Margin" Value="0,2" />
+              </Style>
+
+              <!-- Dot shape (default): selected pip scales up -->
+              <Style Selector="PipsPager.pip-dot ListBoxItem:selected /template/ Border#Pip">
+                <Setter Property="Width" Value="10" />
+                <Setter Property="Height" Value="10" />
+                <Setter Property="CornerRadius" Value="5" />
+              </Style>
+
+              <!-- Pill shape: selected pip elongates horizontally -->
+              <Style Selector="PipsPager.pip-pill ListBoxItem">
+                <Setter Property="Width" Value="16" />
+              </Style>
+              <Style Selector="PipsPager.pip-pill ListBoxItem:selected">
+                <Setter Property="Width" Value="28" />
+              </Style>
+              <Style Selector="PipsPager.pip-pill ListBoxItem:selected /template/ Border#Pip">
+                <Setter Property="Width" Value="24" />
+                <Setter Property="Height" Value="8" />
+                <Setter Property="CornerRadius" Value="4" />
+              </Style>
+
+              <!-- Pill shape vertical -->
+              <Style Selector="PipsPager.pip-pill:vertical ListBoxItem">
+                <Setter Property="Height" Value="16" />
+                <Setter Property="Width" Value="24" />
+              </Style>
+              <Style Selector="PipsPager.pip-pill:vertical ListBoxItem:selected">
+                <Setter Property="Height" Value="28" />
+              </Style>
+              <Style Selector="PipsPager.pip-pill:vertical ListBoxItem:selected /template/ Border#Pip">
+                <Setter Property="Width" Value="8" />
+                <Setter Property="Height" Value="24" />
+                <Setter Property="CornerRadius" Value="4" />
+              </Style>
+
+              <!-- Number shape: rounded square with page number -->
+              <Style Selector="PipsPager.pip-number ListBoxItem">
+                <Setter Property="Width" Value="28" />
+                <Setter Property="Height" Value="28" />
+              </Style>
+              <Style Selector="PipsPager.pip-number ListBoxItem /template/ Border#Pip">
+                <Setter Property="Width" Value="24" />
+                <Setter Property="Height" Value="24" />
+                <Setter Property="CornerRadius" Value="6" />
+                <Setter Property="Background" Value="{DynamicResource MaterialDividerBrush}" />
+                <Setter Property="Opacity" Value="1" />
+              </Style>
+              <Style Selector="PipsPager.pip-number ListBoxItem /template/ Border#Pip TextBlock#PipNumber">
+                <Setter Property="IsVisible" Value="True" />
+                <Setter Property="Foreground" Value="{DynamicResource MaterialBodyBrush}" />
+              </Style>
+              <Style Selector="PipsPager.pip-number ListBoxItem:selected /template/ Border#Pip">
+                <Setter Property="Width" Value="24" />
+                <Setter Property="Height" Value="24" />
+                <Setter Property="CornerRadius" Value="6" />
+                <Setter Property="Background" Value="{DynamicResource MaterialPrimaryMidBrush}" />
+              </Style>
+              <Style Selector="PipsPager.pip-number ListBoxItem:selected /template/ Border#Pip TextBlock#PipNumber">
+                <Setter Property="Foreground" Value="{DynamicResource MaterialPrimaryMidForegroundBrush}" />
+              </Style>
+
+              <!-- Number shape vertical -->
+              <Style Selector="PipsPager.pip-number:vertical ListBoxItem">
+                <Setter Property="Width" Value="28" />
+                <Setter Property="Height" Value="28" />
+              </Style>
+            </ListBox.Styles>
+          </ListBox>
+
+          <Button Name="PART_NextButton"
+                  Theme="{StaticResource MaterialFlatButton}"
+                  Width="32"
+                  Height="32"
+                  Padding="0"
+                  HorizontalContentAlignment="Center"
+                  VerticalContentAlignment="Center"
+                  IsVisible="{TemplateBinding IsNextButtonVisible}"
+                  VerticalAlignment="Center"
+                  HorizontalAlignment="Center"
+                  Margin="4">
+            <PathIcon Width="12" Height="12"
+                      Data="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z" />
+          </Button>
+        </StackPanel>
+      </ControlTemplate>
+    </Setter>
+
+    <Style Selector="^:vertical /template/ Button#PART_PreviousButton PathIcon">
+      <Setter Property="Data" Value="M7.41,15.41L12,10.83L16.59,15.41L18,14L12,8L6,14L7.41,15.41Z" />
+    </Style>
+
+    <Style Selector="^:vertical /template/ Button#PART_NextButton PathIcon">
+      <Setter Property="Data" Value="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z" />
+    </Style>
+
+    <Style Selector="^:first-page /template/ Button#PART_PreviousButton">
+      <Setter Property="Opacity" Value="0" />
+      <Setter Property="IsHitTestVisible" Value="False" />
+    </Style>
+
+    <Style Selector="^:last-page /template/ Button#PART_NextButton">
+      <Setter Property="Opacity" Value="0" />
+      <Setter Property="IsHitTestVisible" Value="False" />
+    </Style>
+  </ControlTheme>
+
+  <ControlTheme x:Key="{x:Type PipsPager}" TargetType="PipsPager"
+                BasedOn="{StaticResource MaterialPipsPager}" />
+</ResourceDictionary>


### PR DESCRIPTION
Added pipspager. 

I looked at the simpletheme from avalonia12 and added material styling on top of it.

- Used material caretstyle for the buttons.
- Added all styles listed here [https://docs.avaloniaui.net/controls/layout/containers/pipspager](https://docs.avaloniaui.net/controls/layout/containers/pipspager)
- Extra: Added pillshape and numberstyle shape for the pips.


Work for the pages styles is WIP, but it also needs the pipspager for the carousel :)


<img width="1190" height="902" alt="pipspager" src="https://github.com/user-attachments/assets/4d902130-0d62-4c28-84a6-feaf6e63b276" />

