### PR TITLE
Avalonia12 pages

### DIFF
--- a/Material.Avalonia.Demo/Extensions/MaterialIconGeometryExt.cs
+++ b/Material.Avalonia.Demo/Extensions/MaterialIconGeometryExt.cs
@@ -1,0 +1,27 @@
+using System;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using Avalonia.Metadata;
+using Material.Icons;
+
+namespace Material.Avalonia.Demo.Extensions
+{
+    public class MaterialIconGeometryExt : MarkupExtension
+    {
+        public MaterialIconGeometryExt() { }
+
+        public MaterialIconGeometryExt(MaterialIconKind kind)
+        {
+            Kind = kind;
+        }
+
+        [ConstructorArgument("kind")]
+        public MaterialIconKind Kind { get; set; }
+
+        public override object ProvideValue(IServiceProvider serviceProvider)
+        {
+            var data = MaterialIconDataProvider.GetData(Kind);
+            return StreamGeometry.Parse(data);
+        }
+    }
+}

--- a/Material.Avalonia.Demo/MainView.axaml
+++ b/Material.Avalonia.Demo/MainView.axaml
@@ -77,6 +77,7 @@
                 <ListBoxItem>Fields line up</ListBoxItem>
                 <ListBoxItem>Lists</ListBoxItem>
                 <ListBoxItem>Material Icons</ListBoxItem>
+                <ListBoxItem>Pages</ListBoxItem>
                 <ListBoxItem>Progress indicators</ListBoxItem>
                 <ListBoxItem>ScrollViewer</ListBoxItem>
                 <!-- <ListBoxItem>Shadows</ListBoxItem> -->
@@ -200,7 +201,10 @@
                 
                 <!-- Icons -->
                 <pages:IconsDemo ScrollViewer.VerticalScrollBarVisibility="Disabled" />
-                
+
+                <!-- Pages -->
+                <pages:PagesDemo />
+
                 <!-- Progress indicators -->
                 <pages:ProgressIndicatorDemo />
                 

--- a/Material.Avalonia.Demo/MainView.axaml
+++ b/Material.Avalonia.Demo/MainView.axaml
@@ -76,6 +76,7 @@
                 <ListBoxItem>Fields line up</ListBoxItem>
                 <ListBoxItem>Lists</ListBoxItem>
                 <ListBoxItem>Material Icons</ListBoxItem>
+                <ListBoxItem>Pages</ListBoxItem>
                 <ListBoxItem>Progress indicators</ListBoxItem>
                 <ListBoxItem>ScrollViewer</ListBoxItem>
                 <!-- <ListBoxItem>Shadows</ListBoxItem> -->
@@ -194,7 +195,10 @@
                 
                 <!-- Icons -->
                 <pages:IconsDemo ScrollViewer.VerticalScrollBarVisibility="Disabled" />
-                
+
+                <!-- Pages -->
+                <pages:PagesDemo />
+
                 <!-- Progress indicators -->
                 <pages:ProgressIndicatorDemo />
                 

--- a/Material.Avalonia.Demo/Pages/PagesDemo.axaml
+++ b/Material.Avalonia.Demo/Pages/PagesDemo.axaml
@@ -23,7 +23,7 @@
                      IsCheckedChanged="DrawerSplit_Checked" />
         <RadioButton Content="Persistent Split" GroupName="DrawerMode"
                      IsCheckedChanged="DrawerSplit_Checked" />
-        <CheckBox Name="DemoDrawerRtlCheckBox" Content="RTL" IsCheckedChanged="DrawerRtl_Checked" />
+        <CheckBox Name="DemoDrawerRtlCheckBox" Content="RightToLeft" IsCheckedChanged="DrawerRtl_Checked" />
       </StackPanel>
       <Border Height="350" BorderBrush="{DynamicResource MaterialDividerBrush}" BorderThickness="1" CornerRadius="4" ClipToBounds="True">
         <DrawerPage Name="DemoDrawer"

--- a/Material.Avalonia.Demo/Pages/PagesDemo.axaml
+++ b/Material.Avalonia.Demo/Pages/PagesDemo.axaml
@@ -2,42 +2,79 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:avalonia="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="600"
+
              x:Class="Material.Avalonia.Demo.Pages.PagesDemo">
   <ScrollViewer>
     <StackPanel Margin="16" Spacing="24">
-      <TextBlock Classes="Headline5" Text="Page Controls (Avalonia 12)" />
-      <TextBlock Classes="Body1" TextWrapping="Wrap"
-                 Text="Page controls." />
+      <TextBlock Classes="Headline5" Text="Page Controls" />
 
-      <!-- ContentPage -->
-      <TextBlock Classes="Headline6" Text="ContentPage" />
-      <Border Height="200" BorderBrush="{DynamicResource MaterialDividerBrush}" BorderThickness="1" CornerRadius="4">
-        <ContentPage Header="My Content Page">
+
+
+      <!-- DrawerPage -->
+      <TextBlock Classes="Headline6" Text="DrawerPage" />
+      <Border Height="350" BorderBrush="{DynamicResource MaterialDividerBrush}" BorderThickness="1" CornerRadius="4" ClipToBounds="True">
+        <DrawerPage DrawerHeaderBackground="{DynamicResource SecondaryHueMidBrush}" 
+                    DrawerHeaderForeground="{DynamicResource MaterialDarkForegroundBrush}"
+                    Header="Drawer Demo" DrawerLength="200" IsOpen="False" DrawerLayoutBehavior="Split">
+
+          <!--Header-->
+          <DrawerPage.DrawerHeader >
+            <StackPanel Height="180" >
+              <Image Width="96" Height="120"
+                     HorizontalAlignment="Center" VerticalAlignment="Center"
+                     Source="avares://Material.Avalonia.Demo/Assets/FavIcon_128x.png" Margin="0,0,0,-8"  />
+              <TextBlock Classes="Headline6" Text="Material Design" HorizontalAlignment="Center" />
+              <TextBlock Classes="Subtitle1" Text="with AvaloniaUI" HorizontalAlignment="Center" />
+            </StackPanel>
+          </DrawerPage.DrawerHeader>
+
+          <!--Drawer-->
+          <DrawerPage.Drawer>
+            <StackPanel Margin="0,8">
+              <ListBox>
+                <ListBoxItem>Item 1</ListBoxItem>
+                <ListBoxItem>Item 2</ListBoxItem>
+                <ListBoxItem>Item 3</ListBoxItem>
+              </ListBox>
+            </StackPanel>
+          </DrawerPage.Drawer>
+
+          <!--Footer-->
+          <DrawerPage.DrawerFooter>
+             <TextBlock Classes="Subtitle1" Text="The Footer" HorizontalAlignment="Center" />
+          </DrawerPage.DrawerFooter>
+
+          <!--Content-->
           <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="8">
-            <TextBlock Classes="Headline6" Text="Hello from ContentPage!" HorizontalAlignment="Center" />
-            <TextBlock Classes="Body2" Text="This is the simplest page control." HorizontalAlignment="Center" />
+            <TextBlock Classes="Headline6" Text="Main Content" HorizontalAlignment="Center" />
+            <TextBlock Classes="Body2" Text="Use the hamburger menu to open the drawer." HorizontalAlignment="Center" />
           </StackPanel>
-        </ContentPage>
+
+
+
+        </DrawerPage>
       </Border>
+
 
       <!-- TabbedPage -->
       <TextBlock Classes="Headline6" Text="TabbedPage" />
       <Border Height="300" BorderBrush="{DynamicResource MaterialDividerBrush}" BorderThickness="1" CornerRadius="4" ClipToBounds="True">
-        <TabbedPage>
-          <ContentPage Header="Home">
+        <TabbedPage TabPlacement="Bottom">
+          <ContentPage Header="Home" Icon="{avalonia:MaterialIconExt Kind=Home}">
             <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="8">
               <TextBlock Classes="Headline6" Text="Home Tab" HorizontalAlignment="Center" />
               <TextBlock Classes="Body2" Text="Welcome to the home tab." HorizontalAlignment="Center" />
             </StackPanel>
           </ContentPage>
-          <ContentPage Header="Favorites">
+          <ContentPage Header="Favorites" Icon="{avalonia:MaterialIconExt Kind=Star}">
             <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="8">
               <TextBlock Classes="Headline6" Text="Favorites Tab" HorizontalAlignment="Center" />
               <TextBlock Classes="Body2" Text="Your favorite items appear here." HorizontalAlignment="Center" />
             </StackPanel>
           </ContentPage>
-          <ContentPage Header="Settings">
+          <ContentPage Header="Settings" Icon="{avalonia:MaterialIconExt Kind=Cog}">
             <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="8">
               <TextBlock Classes="Headline6" Text="Settings Tab" HorizontalAlignment="Center" />
               <TextBlock Classes="Body2" Text="Adjust your preferences." HorizontalAlignment="Center" />
@@ -94,27 +131,18 @@
         </NavigationPage>
       </Border>
 
-      <!-- DrawerPage -->
-      <TextBlock Classes="Headline6" Text="DrawerPage" />
-      <TextBlock Classes="Body2" TextWrapping="Wrap"
-                 Text="DrawerPage provides a navigation drawer (hamburger menu) pattern with a side panel." />
-      <Border Height="350" BorderBrush="{DynamicResource MaterialDividerBrush}" BorderThickness="1" CornerRadius="4" ClipToBounds="True">
-        <DrawerPage Header="Drawer Demo" DrawerLength="200" IsOpen="False">
-          <DrawerPage.Drawer>
-            <StackPanel Margin="0,8">
-              <TextBlock Classes="Subtitle1" Text="Menu" Margin="16,8" />
-              <ListBox>
-                <ListBoxItem>Item 1</ListBoxItem>
-                <ListBoxItem>Item 2</ListBoxItem>
-                <ListBoxItem>Item 3</ListBoxItem>
-              </ListBox>
-            </StackPanel>
-          </DrawerPage.Drawer>
+
+
+
+      <!-- ContentPage -->
+      <TextBlock Classes="Headline6" Text="ContentPage" />
+      <Border Height="200" BorderBrush="{DynamicResource MaterialDividerBrush}" BorderThickness="1" CornerRadius="4">
+        <ContentPage Header="My Content Page">
           <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="8">
-            <TextBlock Classes="Headline6" Text="Main Content" HorizontalAlignment="Center" />
-            <TextBlock Classes="Body2" Text="Use the hamburger menu to open the drawer." HorizontalAlignment="Center" />
+            <TextBlock Classes="Headline6" Text="Hello from ContentPage!" HorizontalAlignment="Center" />
+            <TextBlock Classes="Body2" Text="This is the simplest page control." HorizontalAlignment="Center" />
           </StackPanel>
-        </DrawerPage>
+        </ContentPage>
       </Border>
     </StackPanel>
   </ScrollViewer>

--- a/Material.Avalonia.Demo/Pages/PagesDemo.axaml
+++ b/Material.Avalonia.Demo/Pages/PagesDemo.axaml
@@ -1,0 +1,121 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="600"
+             x:Class="Material.Avalonia.Demo.Pages.PagesDemo">
+  <ScrollViewer>
+    <StackPanel Margin="16" Spacing="24">
+      <TextBlock Classes="Headline5" Text="Page Controls (Avalonia 12)" />
+      <TextBlock Classes="Body1" TextWrapping="Wrap"
+                 Text="Page controls." />
+
+      <!-- ContentPage -->
+      <TextBlock Classes="Headline6" Text="ContentPage" />
+      <Border Height="200" BorderBrush="{DynamicResource MaterialDividerBrush}" BorderThickness="1" CornerRadius="4">
+        <ContentPage Header="My Content Page">
+          <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="8">
+            <TextBlock Classes="Headline6" Text="Hello from ContentPage!" HorizontalAlignment="Center" />
+            <TextBlock Classes="Body2" Text="This is the simplest page control." HorizontalAlignment="Center" />
+          </StackPanel>
+        </ContentPage>
+      </Border>
+
+      <!-- TabbedPage -->
+      <TextBlock Classes="Headline6" Text="TabbedPage" />
+      <Border Height="300" BorderBrush="{DynamicResource MaterialDividerBrush}" BorderThickness="1" CornerRadius="4" ClipToBounds="True">
+        <TabbedPage>
+          <ContentPage Header="Home">
+            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="8">
+              <TextBlock Classes="Headline6" Text="Home Tab" HorizontalAlignment="Center" />
+              <TextBlock Classes="Body2" Text="Welcome to the home tab." HorizontalAlignment="Center" />
+            </StackPanel>
+          </ContentPage>
+          <ContentPage Header="Favorites">
+            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="8">
+              <TextBlock Classes="Headline6" Text="Favorites Tab" HorizontalAlignment="Center" />
+              <TextBlock Classes="Body2" Text="Your favorite items appear here." HorizontalAlignment="Center" />
+            </StackPanel>
+          </ContentPage>
+          <ContentPage Header="Settings">
+            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="8">
+              <TextBlock Classes="Headline6" Text="Settings Tab" HorizontalAlignment="Center" />
+              <TextBlock Classes="Body2" Text="Adjust your preferences." HorizontalAlignment="Center" />
+            </StackPanel>
+          </ContentPage>
+        </TabbedPage>
+      </Border>
+
+      <!-- CarouselPage -->
+      <TextBlock Classes="Headline6" Text="CarouselPage with PipsPager" />
+      <Border Height="250" BorderBrush="{DynamicResource MaterialDividerBrush}" BorderThickness="1" CornerRadius="4" ClipToBounds="True">
+        <Grid RowDefinitions="*,Auto">
+          <CarouselPage Name="DemoCarouselPage"
+                        SelectedIndex="{Binding #CarouselPips.SelectedPageIndex, Mode=TwoWay}">
+            <ContentPage Header="Page 1">
+              <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Classes="Headline5" Text="1" HorizontalAlignment="Center" />
+                <TextBlock Classes="Body1" Text="Use the pips or swipe to navigate" HorizontalAlignment="Center" />
+              </StackPanel>
+            </ContentPage>
+            <ContentPage Header="Page 2">
+              <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Classes="Headline5" Text="2" HorizontalAlignment="Center" />
+                <TextBlock Classes="Body1" Text="Second carousel page" HorizontalAlignment="Center" />
+              </StackPanel>
+            </ContentPage>
+            <ContentPage Header="Page 3">
+              <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Classes="Headline5" Text="3" HorizontalAlignment="Center" />
+                <TextBlock Classes="Body1" Text="Third carousel page" HorizontalAlignment="Center" />
+              </StackPanel>
+            </ContentPage>
+          </CarouselPage>
+          <PipsPager Name="CarouselPips"
+                     Grid.Row="1"
+                     NumberOfPages="3"
+                     HorizontalAlignment="Center"
+                     Margin="0,8" />
+        </Grid>
+      </Border>
+
+      <!-- NavigationPage -->
+      <TextBlock Classes="Headline6" Text="NavigationPage" />
+      <TextBlock Classes="Body2" TextWrapping="Wrap"
+                 Text="NavigationPage provides a stack-based navigation with a top app bar. Push and pop pages with back button support." />
+      <Border Height="350" BorderBrush="{DynamicResource MaterialDividerBrush}" BorderThickness="1" CornerRadius="4" ClipToBounds="True">
+        <NavigationPage Name="DemoNavigationPage">
+          <ContentPage Header="Root Page">
+            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="8">
+              <TextBlock Classes="Headline6" Text="Root Page" HorizontalAlignment="Center" />
+              <Button Name="NavPushButton" Content="Push Detail Page" Classes="Flat" HorizontalAlignment="Center" />
+            </StackPanel>
+          </ContentPage>
+        </NavigationPage>
+      </Border>
+
+      <!-- DrawerPage -->
+      <TextBlock Classes="Headline6" Text="DrawerPage" />
+      <TextBlock Classes="Body2" TextWrapping="Wrap"
+                 Text="DrawerPage provides a navigation drawer (hamburger menu) pattern with a side panel." />
+      <Border Height="350" BorderBrush="{DynamicResource MaterialDividerBrush}" BorderThickness="1" CornerRadius="4" ClipToBounds="True">
+        <DrawerPage Header="Drawer Demo" DrawerLength="200" IsOpen="False">
+          <DrawerPage.Drawer>
+            <StackPanel Margin="0,8">
+              <TextBlock Classes="Subtitle1" Text="Menu" Margin="16,8" />
+              <ListBox>
+                <ListBoxItem>Item 1</ListBoxItem>
+                <ListBoxItem>Item 2</ListBoxItem>
+                <ListBoxItem>Item 3</ListBoxItem>
+              </ListBox>
+            </StackPanel>
+          </DrawerPage.Drawer>
+          <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="8">
+            <TextBlock Classes="Headline6" Text="Main Content" HorizontalAlignment="Center" />
+            <TextBlock Classes="Body2" Text="Use the hamburger menu to open the drawer." HorizontalAlignment="Center" />
+          </StackPanel>
+        </DrawerPage>
+      </Border>
+    </StackPanel>
+  </ScrollViewer>
+</UserControl>

--- a/Material.Avalonia.Demo/Pages/PagesDemo.axaml
+++ b/Material.Avalonia.Demo/Pages/PagesDemo.axaml
@@ -1,8 +1,10 @@
-<UserControl xmlns="https://github.com/avaloniaui"
+﻿<UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:avalonia="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
+             xmlns:controls="clr-namespace:Material.Styles.Controls;assembly=Material.Styles"
+             xmlns:ext="using:Material.Avalonia.Demo.Extensions"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="600"
 
              x:Class="Material.Avalonia.Demo.Pages.PagesDemo">
@@ -11,23 +13,36 @@
       <TextBlock Classes="Headline5" Text="Page Controls" />
 
 
-
       <!-- DrawerPage -->
       <TextBlock Classes="Headline6" Text="DrawerPage" />
+      <StackPanel Orientation="Horizontal" Spacing="12" Margin="0,0,0,8">
+        <TextBlock Classes="Body2" Text="Mode:" VerticalAlignment="Center" />
+        <RadioButton Content="Overlay" GroupName="DrawerMode"
+                     IsCheckedChanged="DrawerOverlay_Checked" />
+        <RadioButton IsChecked="True" Content="Split" GroupName="DrawerMode"
+                     IsCheckedChanged="DrawerSplit_Checked" />
+        <RadioButton Content="Persistent Split" GroupName="DrawerMode"
+                     IsCheckedChanged="DrawerSplit_Checked" />
+        <CheckBox Name="DemoDrawerRtlCheckBox" Content="RTL" IsCheckedChanged="DrawerRtl_Checked" />
+      </StackPanel>
       <Border Height="350" BorderBrush="{DynamicResource MaterialDividerBrush}" BorderThickness="1" CornerRadius="4" ClipToBounds="True">
-        <DrawerPage DrawerHeaderBackground="{DynamicResource SecondaryHueMidBrush}" 
-                    DrawerHeaderForeground="{DynamicResource MaterialDarkForegroundBrush}"
-                    Header="Drawer Demo" DrawerLength="200" IsOpen="False" DrawerLayoutBehavior="Split">
+        <DrawerPage Name="DemoDrawer"
+                    Header="DrawerPage (Overlay)"
+                    DrawerLength="200"
+                    IsOpen="True"
+                    DrawerLayoutBehavior="Split">
 
           <!--Header-->
           <DrawerPage.DrawerHeader >
-            <StackPanel Height="180" >
-              <Image Width="96" Height="120"
-                     HorizontalAlignment="Center" VerticalAlignment="Center"
-                     Source="avares://Material.Avalonia.Demo/Assets/FavIcon_128x.png" Margin="0,0,0,-8"  />
-              <TextBlock Classes="Headline6" Text="Material Design" HorizontalAlignment="Center" />
-              <TextBlock Classes="Subtitle1" Text="with AvaloniaUI" HorizontalAlignment="Center" />
-            </StackPanel>
+            <controls:ColorZone Mode="Accent"   Height="180" >
+              <StackPanel>
+                <Image Width="96" Height="120"
+                       HorizontalAlignment="Center" VerticalAlignment="Center"
+                       Source="avares://Material.Avalonia.Demo/Assets/FavIcon_128x.png" Margin="0,0,0,-8"  />
+                <TextBlock Classes="Headline6" Text="Material Design" HorizontalAlignment="Center" />
+                <TextBlock Classes="Subtitle1" Text="with AvaloniaUI" HorizontalAlignment="Center" />
+              </StackPanel>
+            </controls:ColorZone>
           </DrawerPage.DrawerHeader>
 
           <!--Drawer-->
@@ -43,43 +58,95 @@
 
           <!--Footer-->
           <DrawerPage.DrawerFooter>
-             <TextBlock Classes="Subtitle1" Text="The Footer" HorizontalAlignment="Center" />
+            <TextBlock Classes="Subtitle1" Text="The Footer" HorizontalAlignment="Center" />
           </DrawerPage.DrawerFooter>
 
           <!--Content-->
           <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="8">
             <TextBlock Classes="Headline6" Text="Main Content" HorizontalAlignment="Center" />
-            <TextBlock Classes="Body2" Text="Use the hamburger menu to open the drawer." HorizontalAlignment="Center" />
           </StackPanel>
-
-
 
         </DrawerPage>
       </Border>
 
+      <!-- DrawerPage: Compact Navigation Rail -->
+      <TextBlock Classes="Headline6" Text="DrawerPage (Compact)" />
+      <Border Height="300" BorderBrush="{DynamicResource MaterialDividerBrush}" BorderThickness="1" CornerRadius="4" ClipToBounds="True">
+        <DrawerPage Header="DrawerPage - Compact Navigation Rail"
+                    DrawerLayoutBehavior="CompactInline"
+                    CompactDrawerLength="56"
+                    DrawerLength="200">
+
+          <!--Drawer-->
+          <DrawerPage.Drawer>
+            <StackPanel Spacing="2" Margin="0,8">
+              <Button HorizontalAlignment="Stretch" CornerRadius="0" Theme="{StaticResource MaterialFlatButton}" Classes="primary"
+                      ToolTip.Tip="Home">
+                <StackPanel HorizontalAlignment="Center" Spacing="3">
+                  <avalonia:MaterialIcon Kind="Home"></avalonia:MaterialIcon>
+                  <TextBlock Text="Home" FontSize="9" HorizontalAlignment="Center" />
+                </StackPanel>
+              </Button>
+              <Button HorizontalAlignment="Stretch" CornerRadius="0" Theme="{StaticResource MaterialFlatButton}" Classes="primary"
+                      ToolTip.Tip="Profile">
+                <StackPanel HorizontalAlignment="Center" Spacing="3">
+                  <avalonia:MaterialIcon Kind="Account"></avalonia:MaterialIcon>
+                  <TextBlock Text="Profile" FontSize="9" HorizontalAlignment="Center" />
+                </StackPanel>
+              </Button>
+            </StackPanel>
+          </DrawerPage.Drawer>
+
+          <!--Content-->
+          <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="8">
+            <TextBlock Classes="Headline6" Text="Main Content" HorizontalAlignment="Center" />
+          </StackPanel>
+        </DrawerPage>
+      </Border>
+
+
+
+
+
+
 
       <!-- TabbedPage -->
       <TextBlock Classes="Headline6" Text="TabbedPage" />
+      <StackPanel Orientation="Horizontal" Spacing="12" Margin="0,0,0,8">
+        <TextBlock Classes="Body2" Text="Tab Placement:" VerticalAlignment="Center" />
+        <RadioButton Content="Top" GroupName="TabPlacement" IsChecked="True"
+                     IsCheckedChanged="TabPlacementTop_Checked" />
+        <RadioButton Content="Bottom" GroupName="TabPlacement"
+                     IsCheckedChanged="TabPlacementBottom_Checked" />
+        <RadioButton Content="Left" GroupName="TabPlacement"
+                     IsCheckedChanged="TabPlacementLeft_Checked" />
+        <RadioButton Content="Right" GroupName="TabPlacement"
+                     IsCheckedChanged="TabPlacementRight_Checked" />
+      </StackPanel>
       <Border Height="300" BorderBrush="{DynamicResource MaterialDividerBrush}" BorderThickness="1" CornerRadius="4" ClipToBounds="True">
-        <TabbedPage TabPlacement="Bottom">
-          <ContentPage Header="Home" Icon="{avalonia:MaterialIconExt Kind=Home}">
+        <TabbedPage Name="DemoTabbedPage" TabPlacement="Top">
+
+          <ContentPage Header="Home" Icon="{ext:MaterialIconGeometryExt Home}">
             <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="8">
               <TextBlock Classes="Headline6" Text="Home Tab" HorizontalAlignment="Center" />
               <TextBlock Classes="Body2" Text="Welcome to the home tab." HorizontalAlignment="Center" />
             </StackPanel>
           </ContentPage>
-          <ContentPage Header="Favorites" Icon="{avalonia:MaterialIconExt Kind=Star}">
+
+          <ContentPage Header="Favorites" Icon="{ext:MaterialIconGeometryExt Star}">
             <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="8">
               <TextBlock Classes="Headline6" Text="Favorites Tab" HorizontalAlignment="Center" />
               <TextBlock Classes="Body2" Text="Your favorite items appear here." HorizontalAlignment="Center" />
             </StackPanel>
           </ContentPage>
-          <ContentPage Header="Settings" Icon="{avalonia:MaterialIconExt Kind=Cog}">
+
+          <ContentPage Header="Settings" Icon="{ext:MaterialIconGeometryExt Cog}">
             <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="8">
               <TextBlock Classes="Headline6" Text="Settings Tab" HorizontalAlignment="Center" />
               <TextBlock Classes="Body2" Text="Adjust your preferences." HorizontalAlignment="Center" />
             </StackPanel>
           </ContentPage>
+
         </TabbedPage>
       </Border>
 

--- a/Material.Avalonia.Demo/Pages/PagesDemo.axaml.cs
+++ b/Material.Avalonia.Demo/Pages/PagesDemo.axaml.cs
@@ -1,0 +1,36 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+
+namespace Material.Avalonia.Demo.Pages;
+
+public partial class PagesDemo : UserControl {
+    public PagesDemo() {
+        InitializeComponent();
+    }
+
+    protected override void OnLoaded(RoutedEventArgs e) {
+        base.OnLoaded(e);
+
+        var navPage = this.FindControl<NavigationPage>("DemoNavigationPage");
+        var pushButton = this.FindControl<Button>("NavPushButton");
+
+        if (pushButton != null && navPage != null) {
+            pushButton.Click += async (_, _) => {
+                var detailPage = new ContentPage {
+                    Header = "Detail Page",
+                    Content = new StackPanel {
+                        HorizontalAlignment = global::Avalonia.Layout.HorizontalAlignment.Center,
+                        VerticalAlignment = global::Avalonia.Layout.VerticalAlignment.Center,
+                        Children = {
+                            new TextBlock {
+                                Text = "This is a detail page. Press back to return.",
+                                HorizontalAlignment = global::Avalonia.Layout.HorizontalAlignment.Center
+                            }
+                        }
+                    }
+                };
+                await navPage.PushAsync(detailPage);
+            };
+        }
+    }
+}

--- a/Material.Avalonia.Demo/Pages/PagesDemo.axaml.cs
+++ b/Material.Avalonia.Demo/Pages/PagesDemo.axaml.cs
@@ -1,5 +1,7 @@
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
+using Avalonia.Media;
 
 namespace Material.Avalonia.Demo.Pages;
 
@@ -33,4 +35,52 @@ public partial class PagesDemo : UserControl {
             };
         }
     }
+
+    private void TabPlacementTop_Checked(object? sender, RoutedEventArgs e) {
+        if (sender is RadioButton { IsChecked: true } && DemoTabbedPage != null)
+            DemoTabbedPage.TabPlacement = TabPlacement.Top;
+    }
+
+    private void TabPlacementBottom_Checked(object? sender, RoutedEventArgs e) {
+        if (sender is RadioButton { IsChecked: true } && DemoTabbedPage != null)
+            DemoTabbedPage.TabPlacement = TabPlacement.Bottom;
+    }
+
+    private void TabPlacementLeft_Checked(object? sender, RoutedEventArgs e) {
+        if (sender is RadioButton { IsChecked: true } && DemoTabbedPage != null)
+            DemoTabbedPage.TabPlacement = TabPlacement.Left;
+    }
+
+    private void TabPlacementRight_Checked(object? sender, RoutedEventArgs e) {
+        if (sender is RadioButton { IsChecked: true } && DemoTabbedPage != null)
+            DemoTabbedPage.TabPlacement = TabPlacement.Right;
+    }
+
+    private void DrawerOverlay_Checked(object? sender, RoutedEventArgs e) {
+        if (sender is RadioButton { IsChecked: true })
+            UpdateDrawerDemo(DrawerLayoutBehavior.Overlay);
+    }
+
+    private void DrawerSplit_Checked(object? sender, RoutedEventArgs e) {
+        if (sender is RadioButton { IsChecked: true } radioButton)
+            UpdateDrawerDemo(DrawerLayoutBehavior.Split, radioButton.Content?.ToString() == "Persistent Split");
+    }
+
+    private void DrawerRtl_Checked(object? sender, RoutedEventArgs e) {
+        if (sender is CheckBox checkBox)
+            DemoDrawer.FlowDirection = checkBox.IsChecked == true ? global::Avalonia.Media.FlowDirection.RightToLeft : global::Avalonia.Media.FlowDirection.LeftToRight;
+
+        if (sender is CheckBox)
+            UpdateDrawerDemo(DemoDrawer?.DrawerLayoutBehavior ?? DrawerLayoutBehavior.Overlay, DemoDrawer?.DrawerBehavior == DrawerBehavior.Locked);
+    }
+
+    private void UpdateDrawerDemo(DrawerLayoutBehavior layoutBehavior, bool isPersistent = false) {
+        if (DemoDrawer == null)
+            return;
+        DemoDrawer.DrawerBehavior = isPersistent ? DrawerBehavior.Locked : DrawerBehavior.Auto;
+        DemoDrawer.DrawerLayoutBehavior = layoutBehavior;
+        DemoDrawer.IsOpen = layoutBehavior == DrawerLayoutBehavior.Split;
+
+    }
+
 }

--- a/Material.Styles/MaterialToolKit.xaml
+++ b/Material.Styles/MaterialToolKit.xaml
@@ -37,13 +37,16 @@
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/CalendarDayButton.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/CalendarItem.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/Carousel.axaml" />
+        <ResourceInclude Source="avares://Material.Styles/Resources/Themes/CarouselPage.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/CheckBox.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/ComboBox.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/ComboBoxItem.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/ContentControl.axaml" />
+        <ResourceInclude Source="avares://Material.Styles/Resources/Themes/ContentPage.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/ContextMenu.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/DataValidationErrors.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/DatePicker.axaml" />
+        <ResourceInclude Source="avares://Material.Styles/Resources/Themes/DrawerPage.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/DropDownButton.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/EmbeddableControlRoot.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/Expander.axaml" />
@@ -62,6 +65,7 @@
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/MenuFlyoutPresenter.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/MenuItem.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/MenuScrollViewer.axaml" />
+        <ResourceInclude Source="avares://Material.Styles/Resources/Themes/NavigationPage.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/NotificationCard.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/NumericUpDown.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/OverlayPopupHost.axaml" />
@@ -84,6 +88,7 @@
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/TabItem.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/TabStrip.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/TabStripItem.axaml" />
+        <ResourceInclude Source="avares://Material.Styles/Resources/Themes/TabbedPage.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/TextBlock.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/TextBox.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/TextSelectionHandle.axaml" />

--- a/Material.Styles/MaterialToolKit.xaml
+++ b/Material.Styles/MaterialToolKit.xaml
@@ -37,13 +37,16 @@
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/CalendarDayButton.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/CalendarItem.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/Carousel.axaml" />
+        <ResourceInclude Source="avares://Material.Styles/Resources/Themes/CarouselPage.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/CheckBox.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/ComboBox.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/ComboBoxItem.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/ContentControl.axaml" />
+        <ResourceInclude Source="avares://Material.Styles/Resources/Themes/ContentPage.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/ContextMenu.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/DataValidationErrors.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/DatePicker.axaml" />
+        <ResourceInclude Source="avares://Material.Styles/Resources/Themes/DrawerPage.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/DropDownButton.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/EmbeddableControlRoot.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/Expander.axaml" />
@@ -62,6 +65,7 @@
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/MenuFlyoutPresenter.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/MenuItem.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/MenuScrollViewer.axaml" />
+        <ResourceInclude Source="avares://Material.Styles/Resources/Themes/NavigationPage.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/NotificationCard.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/NumericUpDown.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/OverlayPopupHost.axaml" />
@@ -83,6 +87,7 @@
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/TabItem.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/TabStrip.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/TabStripItem.axaml" />
+        <ResourceInclude Source="avares://Material.Styles/Resources/Themes/TabbedPage.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/TextBlock.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/TextBox.axaml" />
         <ResourceInclude Source="avares://Material.Styles/Resources/Themes/TextSelectionHandle.axaml" />

--- a/Material.Styles/Resources/Themes/CarouselPage.axaml
+++ b/Material.Styles/Resources/Themes/CarouselPage.axaml
@@ -1,0 +1,19 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  <ControlTheme x:Key="MaterialCarouselPage" TargetType="CarouselPage">
+    <Setter Property="Background" Value="{DynamicResource MaterialPaperBrush}" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Carousel Name="PART_Carousel"
+                  Background="{TemplateBinding Background}"
+                  ItemTemplate="{TemplateBinding PageTemplate}"
+                  PageTransition="{TemplateBinding PageTransition}"
+                  ItemsPanel="{TemplateBinding ItemsPanel}"
+                  HorizontalAlignment="Stretch"
+                  VerticalAlignment="Stretch" />
+      </ControlTemplate>
+    </Setter>
+  </ControlTheme>
+  <ControlTheme x:Key="{x:Type CarouselPage}" TargetType="CarouselPage"
+                BasedOn="{StaticResource MaterialCarouselPage}" />
+</ResourceDictionary>

--- a/Material.Styles/Resources/Themes/ContentPage.axaml
+++ b/Material.Styles/Resources/Themes/ContentPage.axaml
@@ -1,0 +1,32 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  <ControlTheme x:Key="MaterialContentPage" TargetType="ContentPage">
+    <Setter Property="Background" Value="{DynamicResource MaterialPaperBrush}" />
+    <Setter Property="Foreground" Value="{DynamicResource MaterialBodyBrush}" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <DockPanel>
+          <ContentPresenter Name="PART_TopCommandBar"
+                            DockPanel.Dock="Top"
+                            HorizontalContentAlignment="Stretch"
+                            IsVisible="False" />
+          <ContentPresenter Name="PART_BottomCommandBar"
+                            DockPanel.Dock="Bottom"
+                            HorizontalContentAlignment="Stretch"
+                            IsVisible="False" />
+          <ContentPresenter Name="PART_ContentPresenter"
+                            HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                            VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            Content="{TemplateBinding Content}"
+                            ContentTemplate="{TemplateBinding ContentTemplate}"
+                            CornerRadius="{TemplateBinding CornerRadius}" />
+        </DockPanel>
+      </ControlTemplate>
+    </Setter>
+  </ControlTheme>
+  <ControlTheme x:Key="{x:Type ContentPage}" TargetType="ContentPage"
+                BasedOn="{StaticResource MaterialContentPage}" />
+</ResourceDictionary>

--- a/Material.Styles/Resources/Themes/DrawerPage.axaml
+++ b/Material.Styles/Resources/Themes/DrawerPage.axaml
@@ -223,6 +223,5 @@
       <Setter Property="IsVisible" Value="False" />
     </Style>
   </ControlTheme>
-  <ControlTheme x:Key="{x:Type DrawerPage}" TargetType="DrawerPage"
-                BasedOn="{StaticResource MaterialDrawerPage}" />
+  <ControlTheme x:Key="{x:Type DrawerPage}" TargetType="DrawerPage"    BasedOn="{StaticResource MaterialDrawerPage}" />
 </ResourceDictionary>

--- a/Material.Styles/Resources/Themes/DrawerPage.axaml
+++ b/Material.Styles/Resources/Themes/DrawerPage.axaml
@@ -6,6 +6,7 @@
   <ControlTheme x:Key="MaterialDrawerPage" TargetType="DrawerPage">
     <Setter Property="Background" Value="{DynamicResource MaterialPaperBrush}" />
     <Setter Property="Foreground" Value="{DynamicResource MaterialBodyBrush}" />
+    <Setter Property="DrawerBackground" Value="{DynamicResource MaterialPaperBrush}" />
     <Setter Property="Template">
       <ControlTemplate>
         <SplitView Name="PART_SplitView"
@@ -25,6 +26,7 @@
                             HorizontalAlignment="Left"
                             Width="{TemplateBinding CompactDrawerLength}"
                             Height="{TemplateBinding CompactDrawerLength}"
+                             AutomationProperties.Name="Toggle navigation drawer"
                             ToolTip.Tip="Toggle navigation drawer">
                 <Panel>
                   <PathIcon
@@ -75,6 +77,7 @@
                                 Background="Transparent"
                                 Foreground="{DynamicResource MaterialPrimaryMidForegroundBrush}"
                                 DockPanel.Dock="Left"
+                                 AutomationProperties.Name="Toggle navigation drawer"
                                 ToolTip.Tip="Toggle navigation drawer">
                     <Panel>
                       <PathIcon
@@ -118,6 +121,7 @@
                                 Background="Transparent"
                                 Foreground="{DynamicResource MaterialPrimaryMidForegroundBrush}"
                                 DockPanel.Dock="Left"
+                                 AutomationProperties.Name="Toggle navigation drawer"
                                 ToolTip.Tip="Toggle navigation drawer">
                     <Panel>
                       <PathIcon

--- a/Material.Styles/Resources/Themes/DrawerPage.axaml
+++ b/Material.Styles/Resources/Themes/DrawerPage.axaml
@@ -1,0 +1,219 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  <x:Double x:Key="MaterialDrawerPageNavBarHeight">56</x:Double>
+  <StreamGeometry x:Key="MaterialDrawerPaneButtonIcon">M3 17h18a1 1 0 0 1 .117 1.993L21 19H3a1 1 0 0 1-.117-1.993L3 17h18H3Zm0-6 18-.002a1 1 0 0 1 .117 1.993l-.117.007L3 13a1 1 0 0 1-.117-1.993L3 11l18-.002L3 11Zm0-6h18a1 1 0 0 1 .117 1.993L21 7H3a1 1 0 0 1-.117-1.993L3 5h18H3Z</StreamGeometry>
+
+  <ControlTheme x:Key="MaterialDrawerPage" TargetType="DrawerPage">
+    <Setter Property="Background" Value="{DynamicResource MaterialPaperBrush}" />
+    <Setter Property="Foreground" Value="{DynamicResource MaterialBodyBrush}" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <SplitView Name="PART_SplitView"
+                   DisplayMode="{TemplateBinding DisplayMode}"
+                   OpenPaneLength="{TemplateBinding DrawerLength}"
+                   CompactPaneLength="{TemplateBinding CompactDrawerLength}"
+                   PaneBackground="{Binding DrawerBackground, RelativeSource={RelativeSource TemplatedParent}}"
+                   IsPaneOpen="{Binding IsOpen, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}">
+          <SplitView.Pane>
+            <DockPanel Background="{TemplateBinding DrawerBackground}">
+              <ToggleButton Name="PART_CompactPaneToggle"
+                            DockPanel.Dock="Top"
+                            Theme="{StaticResource MaterialFlatToggleButton}"
+                            IsChecked="{Binding #PART_SplitView.IsPaneOpen, Mode=TwoWay}"
+                            Background="Transparent"
+                            IsVisible="False"
+                            HorizontalAlignment="Left"
+                            Width="{TemplateBinding CompactDrawerLength}"
+                            Height="{TemplateBinding CompactDrawerLength}"
+                            ToolTip.Tip="Toggle navigation drawer">
+                <Panel>
+                  <PathIcon
+                    IsVisible="{Binding DrawerIcon, RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static ObjectConverters.IsNull}}"
+                    Data="{DynamicResource MaterialDrawerPaneButtonIcon}"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"/>
+                  <ContentPresenter
+                    Name="PART_CompactPaneIconPresenter"
+                    Content="{TemplateBinding DrawerIcon}"
+                    ContentTemplate="{TemplateBinding DrawerIconTemplate}"
+                    IsVisible="{Binding DrawerIcon, RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static ObjectConverters.IsNotNull}}"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"/>
+                </Panel>
+              </ToggleButton>
+              <ContentPresenter Name="PART_DrawerHeader"
+                                DockPanel.Dock="Top"
+                                Content="{TemplateBinding DrawerHeader}"
+                                ContentTemplate="{TemplateBinding DrawerHeaderTemplate}"
+                                Background="{TemplateBinding DrawerHeaderBackground}"
+                                IsVisible="{TemplateBinding DrawerHeader, Converter={x:Static ObjectConverters.IsNotNull}}" />
+              <ContentPresenter Name="PART_DrawerFooter"
+                                DockPanel.Dock="Bottom"
+                                Content="{TemplateBinding DrawerFooter}"
+                                ContentTemplate="{TemplateBinding DrawerFooterTemplate}"
+                                Background="{TemplateBinding DrawerFooterBackground}"
+                                IsVisible="{TemplateBinding DrawerFooter, Converter={x:Static ObjectConverters.IsNotNull}}" />
+              <ContentPresenter Name="PART_DrawerPresenter"
+                                HorizontalContentAlignment="Stretch"
+                                VerticalContentAlignment="Stretch"
+                                Content="{TemplateBinding Drawer}"
+                                ContentTemplate="{TemplateBinding DrawerTemplate}" />
+            </DockPanel>
+          </SplitView.Pane>
+          <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+            <DockPanel Name="PART_ContentDock">
+              <Border Name="PART_TopBar"
+                      Padding="4"
+                      Height="{DynamicResource MaterialDrawerPageNavBarHeight}"
+                      Background="{DynamicResource MaterialPrimaryMidBrush}"
+                      BoxShadow="0 2 4 0 #33000000"
+                      DockPanel.Dock="Top">
+                <DockPanel HorizontalAlignment="Stretch">
+                  <ToggleButton x:Name="PART_PaneButton"
+                                Theme="{StaticResource MaterialFlatToggleButton}"
+                                IsChecked="{Binding #PART_SplitView.IsPaneOpen, Mode=TwoWay}"
+                                Background="Transparent"
+                                Foreground="{DynamicResource MaterialPrimaryMidForegroundBrush}"
+                                DockPanel.Dock="Left"
+                                ToolTip.Tip="Toggle navigation drawer">
+                    <Panel>
+                      <PathIcon
+                        IsVisible="{Binding DrawerIcon, RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static ObjectConverters.IsNull}}"
+                        Data="{DynamicResource MaterialDrawerPaneButtonIcon}"
+                        Foreground="{DynamicResource MaterialPrimaryMidForegroundBrush}"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"/>
+                      <ContentPresenter
+                        Name="PART_PaneIconPresenter"
+                        Content="{TemplateBinding DrawerIcon}"
+                        ContentTemplate="{TemplateBinding DrawerIconTemplate}"
+                        IsVisible="{Binding DrawerIcon, RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static ObjectConverters.IsNotNull}}"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"/>
+                    </Panel>
+                  </ToggleButton>
+                  <ContentPresenter x:Name="PART_TitlePresenter"
+                                    Content="{TemplateBinding Header}"
+                                    ContentTemplate="{TemplateBinding HeaderTemplate}"
+                                    Foreground="{DynamicResource MaterialPrimaryMidForegroundBrush}"
+                                    VerticalAlignment="Center"
+                                    VerticalContentAlignment="Center"
+                                    FontSize="20"
+                                    FontWeight="Medium"
+                                    Margin="8,0,0,0"
+                                    IsVisible="{TemplateBinding Header, Converter={x:Static ObjectConverters.IsNotNull}}" />
+                </DockPanel>
+              </Border>
+              <Border Name="PART_BottomBar"
+                      Padding="4"
+                      Height="{DynamicResource MaterialDrawerPageNavBarHeight}"
+                      Background="{DynamicResource MaterialPrimaryMidBrush}"
+                      BoxShadow="0 -2 4 0 #33000000"
+                      DockPanel.Dock="Bottom"
+                      IsVisible="False">
+                <DockPanel HorizontalAlignment="Stretch">
+                  <ToggleButton x:Name="PART_BottomPaneButton"
+                                Theme="{StaticResource MaterialFlatToggleButton}"
+                                IsChecked="{Binding #PART_SplitView.IsPaneOpen, Mode=TwoWay}"
+                                Background="Transparent"
+                                Foreground="{DynamicResource MaterialPrimaryMidForegroundBrush}"
+                                DockPanel.Dock="Left"
+                                ToolTip.Tip="Toggle navigation drawer">
+                    <Panel>
+                      <PathIcon
+                        IsVisible="{Binding DrawerIcon, RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static ObjectConverters.IsNull}}"
+                        Data="{DynamicResource MaterialDrawerPaneButtonIcon}"
+                        Foreground="{DynamicResource MaterialPrimaryMidForegroundBrush}"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"/>
+                      <ContentPresenter
+                        Name="PART_BottomPaneIconPresenter"
+                        Content="{TemplateBinding DrawerIcon}"
+                        ContentTemplate="{TemplateBinding DrawerIconTemplate}"
+                        IsVisible="{Binding DrawerIcon, RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static ObjectConverters.IsNotNull}}"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"/>
+                    </Panel>
+                  </ToggleButton>
+                  <ContentPresenter x:Name="PART_BottomTitlePresenter"
+                                    Content="{TemplateBinding Header}"
+                                    ContentTemplate="{TemplateBinding HeaderTemplate}"
+                                    Foreground="{DynamicResource MaterialPrimaryMidForegroundBrush}"
+                                    VerticalAlignment="Center"
+                                    VerticalContentAlignment="Center"
+                                    FontSize="20"
+                                    FontWeight="Medium"
+                                    Margin="8,0,0,0"
+                                    IsVisible="{TemplateBinding Header, Converter={x:Static ObjectConverters.IsNotNull}}" />
+                </DockPanel>
+              </Border>
+              <ContentPresenter Name="PART_ContentPresenter"
+                                HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                Content="{TemplateBinding Content}"
+                                ContentTemplate="{TemplateBinding ContentTemplate}"
+                                CornerRadius="{TemplateBinding CornerRadius}" />
+            </DockPanel>
+            <Border Name="PART_Backdrop"
+                    Background="{TemplateBinding BackdropBrush}"
+                    IsVisible="False"
+                    IsHitTestVisible="False" />
+          </Grid>
+        </SplitView>
+      </ControlTemplate>
+    </Setter>
+    <Style Selector="^:placement-right /template/ ToggleButton#PART_PaneButton">
+      <Setter Property="DockPanel.Dock" Value="Right" />
+    </Style>
+    <Style Selector="^:placement-bottom /template/ Border#PART_TopBar">
+      <Setter Property="IsVisible" Value="False" />
+    </Style>
+    <Style Selector="^:placement-bottom /template/ Border#PART_BottomBar">
+      <Setter Property="IsVisible" Value="True" />
+    </Style>
+    <Style Selector="^:placement-bottom[DisplayMode=CompactOverlay] /template/ Border#PART_BottomBar">
+      <Setter Property="IsVisible" Value="False" />
+    </Style>
+    <Style Selector="^:placement-bottom[DisplayMode=CompactInline] /template/ Border#PART_BottomBar">
+      <Setter Property="IsVisible" Value="False" />
+    </Style>
+    <Style Selector="^:placement-bottom /template/ ToggleButton#PART_CompactPaneToggle">
+      <Setter Property="DockPanel.Dock" Value="Left" />
+    </Style>
+    <Style Selector="^:placement-top /template/ ToggleButton#PART_CompactPaneToggle">
+      <Setter Property="DockPanel.Dock" Value="Left" />
+    </Style>
+    <Style Selector="^[DrawerBehavior=Locked] /template/ Border#PART_TopBar">
+      <Setter Property="IsVisible" Value="False" />
+    </Style>
+    <Style Selector="^[DrawerBehavior=Disabled] /template/ Border#PART_TopBar">
+      <Setter Property="IsVisible" Value="False" />
+    </Style>
+    <Style Selector="^:detail-is-navpage /template/ Border#PART_TopBar">
+      <Setter Property="IsVisible" Value="False" />
+    </Style>
+    <Style Selector="^[DisplayMode=CompactOverlay] /template/ Border#PART_TopBar">
+      <Setter Property="IsVisible" Value="False" />
+    </Style>
+    <Style Selector="^[DisplayMode=CompactOverlay] /template/ ToggleButton#PART_CompactPaneToggle">
+      <Setter Property="IsVisible" Value="True" />
+    </Style>
+    <Style Selector="^[DisplayMode=CompactInline] /template/ Border#PART_TopBar">
+      <Setter Property="IsVisible" Value="False" />
+    </Style>
+    <Style Selector="^[DisplayMode=CompactInline] /template/ ToggleButton#PART_CompactPaneToggle">
+      <Setter Property="IsVisible" Value="True" />
+    </Style>
+    <Style Selector="^[IsInNavigationPage=True] /template/ Border#PART_TopBar">
+      <Setter Property="IsVisible" Value="False" />
+    </Style>
+    <Style Selector="^:detail-is-navpage /template/ ToggleButton#PART_CompactPaneToggle">
+      <Setter Property="IsVisible" Value="False" />
+    </Style>
+  </ControlTheme>
+  <ControlTheme x:Key="{x:Type DrawerPage}" TargetType="DrawerPage"
+                BasedOn="{StaticResource MaterialDrawerPage}" />
+</ResourceDictionary>

--- a/Material.Styles/Resources/Themes/DrawerPage.axaml
+++ b/Material.Styles/Resources/Themes/DrawerPage.axaml
@@ -22,6 +22,7 @@
             <DockPanel Background="{TemplateBinding DrawerBackground}">
               <ToggleButton Name="PART_CompactPaneToggle"
                             DockPanel.Dock="Top"
+                            WindowDecorationProperties.ElementRole="DecorationsElement"
                             Theme="{StaticResource MaterialFlatToggleButton}"
                             IsChecked="{Binding #PART_SplitView.IsPaneOpen, Mode=TwoWay}"
                             Background="Transparent"
@@ -29,7 +30,7 @@
                             HorizontalAlignment="Left"
                             Width="{TemplateBinding CompactDrawerLength}"
                             Height="{TemplateBinding CompactDrawerLength}"
-                             AutomationProperties.Name="Toggle navigation drawer"
+                            AutomationProperties.Name="Toggle navigation drawer"
                             ToolTip.Tip="Toggle navigation drawer">
                 <Panel>
                   <PathIcon
@@ -76,6 +77,7 @@
                       ZIndex="1">
                 <DockPanel HorizontalAlignment="Stretch">
                   <ToggleButton x:Name="PART_PaneButton"
+                                                            WindowDecorationProperties.ElementRole="DecorationsElement"
                                 Theme="{StaticResource MaterialFlatToggleButton}"
                                 IsChecked="{Binding #PART_SplitView.IsPaneOpen, Mode=TwoWay}"
                                 Background="Transparent"

--- a/Material.Styles/Resources/Themes/DrawerPage.axaml
+++ b/Material.Styles/Resources/Themes/DrawerPage.axaml
@@ -1,15 +1,18 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:assists="clr-namespace:Material.Styles.Assists">
   <x:Double x:Key="MaterialDrawerPageNavBarHeight">56</x:Double>
   <StreamGeometry x:Key="MaterialDrawerPaneButtonIcon">M3 17h18a1 1 0 0 1 .117 1.993L21 19H3a1 1 0 0 1-.117-1.993L3 17h18H3Zm0-6 18-.002a1 1 0 0 1 .117 1.993l-.117.007L3 13a1 1 0 0 1-.117-1.993L3 11l18-.002L3 11Zm0-6h18a1 1 0 0 1 .117 1.993L21 7H3a1 1 0 0 1-.117-1.993L3 5h18H3Z</StreamGeometry>
+
+  <SolidColorBrush x:Key="MaterialDrawerBackgroundBrush" Color="{DynamicResource MaterialCardBackgroundColor}" />
 
   <ControlTheme x:Key="MaterialDrawerPage" TargetType="DrawerPage">
     <Setter Property="Background" Value="{DynamicResource MaterialPaperBrush}" />
     <Setter Property="Foreground" Value="{DynamicResource MaterialBodyBrush}" />
-    <Setter Property="DrawerBackground" Value="{DynamicResource MaterialPaperBrush}" />
+    <Setter Property="DrawerBackground" Value="{DynamicResource MaterialDrawerBackgroundBrush}" />
     <Setter Property="Template">
       <ControlTemplate>
-        <SplitView Name="PART_SplitView"
+        <SplitView Name="PART_SplitView" 
                    DisplayMode="{TemplateBinding DisplayMode}"
                    OpenPaneLength="{TemplateBinding DrawerLength}"
                    CompactPaneLength="{TemplateBinding CompactDrawerLength}"
@@ -68,8 +71,9 @@
                       Padding="4"
                       Height="{DynamicResource MaterialDrawerPageNavBarHeight}"
                       Background="{DynamicResource MaterialPrimaryMidBrush}"
-                      BoxShadow="0 2 4 0 #33000000"
-                      DockPanel.Dock="Top">
+                      assists:ShadowAssist.ShadowDepth="Depth2"
+                      DockPanel.Dock="Top"
+                      ZIndex="1">
                 <DockPanel HorizontalAlignment="Stretch">
                   <ToggleButton x:Name="PART_PaneButton"
                                 Theme="{StaticResource MaterialFlatToggleButton}"
@@ -111,8 +115,9 @@
                       Padding="4"
                       Height="{DynamicResource MaterialDrawerPageNavBarHeight}"
                       Background="{DynamicResource MaterialPrimaryMidBrush}"
-                      BoxShadow="0 -2 4 0 #33000000"
+                      assists:ShadowAssist.ShadowDepth="Depth2"
                       DockPanel.Dock="Bottom"
+                      ZIndex="1"
                       IsVisible="False">
                 <DockPanel HorizontalAlignment="Stretch">
                   <ToggleButton x:Name="PART_BottomPaneButton"

--- a/Material.Styles/Resources/Themes/NavigationPage.axaml
+++ b/Material.Styles/Resources/Themes/NavigationPage.axaml
@@ -1,0 +1,140 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  <StreamGeometry x:Key="MaterialNavigationPageMenuIcon">M3 17h18a1 1 0 0 1 .117 1.993L21 19H3a1 1 0 0 1-.117-1.993L3 17h18H3Zm0-6 18-.002a1 1 0 0 1 .117 1.993l-.117.007L3 13a1 1 0 0 1-.117-1.993L3 11l18-.002L3 11Zm0-6h18a1 1 0 0 1 .117 1.993L21 7H3a1 1 0 0 1-.117-1.993L3 5h18H3Z</StreamGeometry>
+  <StreamGeometry x:Key="MaterialNavigationPageBackIcon">M12.7347,4.20949 C13.0332,3.92233 13.508,3.93153 13.7952,4.23005 C14.0823,4.52857 14.0731,5.00335 13.7746,5.29051 L5.50039,13.25 L24.2532,13.25 C24.6674,13.25 25.0032,13.5858 25.0032,13.9999982 C25.0032,14.4142 24.6674,14.75 24.2532,14.75 L5.50137,14.75 L13.7746,22.7085 C14.0731,22.9957 14.0823,23.4705 13.7952,23.769 C13.508,24.0675 13.0332,24.0767 12.7347,23.7896 L3.30673,14.7202 C2.89776,14.3268 2.89776,13.6723 3.30673,13.2788 L12.7347,4.20949 Z</StreamGeometry>
+
+  <ControlTheme x:Key="MaterialNavigationPage" TargetType="NavigationPage">
+    <Setter Property="Background" Value="{DynamicResource MaterialPaperBrush}" />
+    <Setter Property="PageTransition">
+      <Setter.Value>
+        <PageSlide Duration="0:0:0.3" Orientation="Horizontal" FillMode="Forward">
+          <PageSlide.SlideInEasing>
+            <SplineEasing X1="0.4" Y1="0" X2="0.2" Y2="1" />
+          </PageSlide.SlideInEasing>
+          <PageSlide.SlideOutEasing>
+            <SplineEasing X1="0.4" Y1="0" X2="0.2" Y2="1" />
+          </PageSlide.SlideOutEasing>
+        </PageSlide>
+      </Setter.Value>
+    </Setter>
+    <Setter Property="ModalTransition">
+      <Setter.Value>
+        <PageSlide Duration="0:0:0.25" Orientation="Vertical" FillMode="Forward">
+          <PageSlide.SlideInEasing>
+            <SplineEasing X1="0.4" Y1="0" X2="0.2" Y2="1" />
+          </PageSlide.SlideInEasing>
+          <PageSlide.SlideOutEasing>
+            <SplineEasing X1="0.4" Y1="0" X2="0.2" Y2="1" />
+          </PageSlide.SlideOutEasing>
+        </PageSlide>
+      </Setter.Value>
+    </Setter>
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Panel ClipToBounds="True">
+          <DockPanel>
+            <Border Name="PART_NavBarSpacer"
+                    Height="{TemplateBinding EffectiveBarHeight}"
+                    IsVisible="False"
+                    DockPanel.Dock="Top" />
+            <ContentPresenter Name="PART_BottomCommandBar"
+                              DockPanel.Dock="Bottom"
+                              HorizontalContentAlignment="Stretch"
+                              Background="{TemplateBinding Background}"
+                              Content="{Binding CurrentPage?.(NavigationPage.BottomCommandBar), RelativeSource={RelativeSource TemplatedParent}, FallbackValue={x:Null}}" />
+            <Grid Name="PART_ContentHost"
+                  Background="{TemplateBinding Background}"
+                  ClipToBounds="True">
+              <ContentPresenter Name="PART_PageBackPresenter"
+                                HorizontalAlignment="Stretch"
+                                VerticalAlignment="Stretch" />
+              <ContentPresenter Name="PART_PagePresenter"
+                                HorizontalAlignment="Stretch"
+                                VerticalAlignment="Stretch" />
+            </Grid>
+          </DockPanel>
+          <Border Name="PART_NavigationBar"
+                  ZIndex="1"
+                  VerticalAlignment="Top"
+                  ClipToBounds="True"
+                  Height="{TemplateBinding EffectiveBarHeight}"
+                  Background="{DynamicResource MaterialPrimaryMidBrush}"
+                  BoxShadow="0 2 4 0 #33000000">
+            <Grid Margin="12,0,0,0" ColumnDefinitions="Auto, *, Auto">
+              <Button x:Name="PART_BackButton"
+                      Grid.Column="0"
+                      Theme="{StaticResource MaterialFlatButton}"
+                      Background="Transparent"
+                      Foreground="{DynamicResource MaterialPrimaryMidForegroundBrush}"
+                      IsVisible="{TemplateBinding IsBackButtonEffectivelyVisible}"
+                      VerticalAlignment="Stretch"
+                      Padding="8,0"
+                      ToolTip.Tip="{x:Null}">
+                <Panel Background="Transparent">
+                  <Path Data="{DynamicResource MaterialNavigationPageBackIcon}"
+                        x:Name="PART_BackButtonDefaultIcon"
+                        Fill="{DynamicResource MaterialPrimaryMidForegroundBrush}"
+                        Width="24"
+                        Height="24"
+                        Stretch="Uniform"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center" />
+                  <ContentPresenter
+                    x:Name="PART_BackButtonContentPresenter"
+                    VerticalAlignment="Center"
+                    HorizontalAlignment="Center"/>
+                </Panel>
+              </Button>
+              <ContentPresenter Name="PART_Header"
+                                Grid.Column="1"
+                                FontSize="20"
+                                FontWeight="Medium"
+                                Foreground="{DynamicResource MaterialPrimaryMidForegroundBrush}"
+                                Content="{Binding CurrentPage?.Header, RelativeSource={RelativeSource TemplatedParent}, FallbackValue={x:Null}}"
+                                ContentTemplate="{Binding CurrentPage?.HeaderTemplate, RelativeSource={RelativeSource TemplatedParent}, FallbackValue={x:Null}}"
+                                VerticalAlignment="Center"
+                                HorizontalAlignment="Stretch"
+                                HorizontalContentAlignment="Stretch"
+                                Margin="0,0,12,0" />
+              <ContentPresenter Name="PART_TopCommandBar"
+                                Grid.Column="2"
+                                HorizontalAlignment="Right"
+                                VerticalContentAlignment="Stretch"
+                                Foreground="{DynamicResource MaterialPrimaryMidForegroundBrush}"
+                                Content="{Binding CurrentPage?.(NavigationPage.TopCommandBar), RelativeSource={RelativeSource TemplatedParent}, FallbackValue={x:Null}}" />
+            </Grid>
+          </Border>
+          <Border Name="PART_NavBarShadow"
+                  ZIndex="1"
+                  VerticalAlignment="Top"
+                  IsVisible="False"
+                  Height="4"
+                  IsHitTestVisible="False">
+            <Border.Background>
+              <LinearGradientBrush StartPoint="0%,0%" EndPoint="0%,100%">
+                <GradientStop Color="#0C000000" Offset="0" />
+                <GradientStop Color="#00000000" Offset="1" />
+              </LinearGradientBrush>
+            </Border.Background>
+          </Border>
+          <ContentPresenter Name="PART_ModalBackPresenter"
+                            ZIndex="99"
+                            IsVisible="False"
+                            Background="{TemplateBinding Background}" />
+          <ContentPresenter Name="PART_ModalPresenter"
+                            ZIndex="100"
+                            IsVisible="False"
+                            Background="{TemplateBinding Background}" />
+        </Panel>
+      </ControlTemplate>
+    </Setter>
+    <Style Selector="^:nav-bar-inset /template/ Border#PART_NavBarSpacer">
+      <Setter Property="IsVisible" Value="True" />
+    </Style>
+    <Style Selector="^:nav-bar-compact /template/ ContentPresenter#PART_TopCommandBar CommandBar">
+      <Setter Property="DefaultLabelPosition" Value="Collapsed" />
+    </Style>
+  </ControlTheme>
+  <ControlTheme x:Key="{x:Type NavigationPage}" TargetType="NavigationPage"
+                BasedOn="{StaticResource MaterialNavigationPage}" />
+</ResourceDictionary>

--- a/Material.Styles/Resources/Themes/NavigationPage.axaml
+++ b/Material.Styles/Resources/Themes/NavigationPage.axaml
@@ -63,6 +63,7 @@
             <Grid Margin="12,0,0,0" ColumnDefinitions="Auto, *, Auto">
               <Button x:Name="PART_BackButton"
                       Grid.Column="0"
+                      WindowDecorationProperties.ElementRole="DecorationsElement"
                       Theme="{StaticResource MaterialFlatButton}"
                       Background="Transparent"
                       Foreground="{DynamicResource MaterialPrimaryMidForegroundBrush}"

--- a/Material.Styles/Resources/Themes/NavigationPage.axaml
+++ b/Material.Styles/Resources/Themes/NavigationPage.axaml
@@ -80,9 +80,9 @@
                         HorizontalAlignment="Center"
                         VerticalAlignment="Center" />
                   <ContentPresenter
-                    x:Name="PART_BackButtonContentPresenter"
-                    VerticalAlignment="Center"
-                    HorizontalAlignment="Center"/>
+                  x:Name="PART_BackButtonContentPresenter"
+                  VerticalAlignment="Center"
+                  HorizontalAlignment="Center"/>
                 </Panel>
               </Button>
               <ContentPresenter Name="PART_Header"
@@ -135,6 +135,5 @@
       <Setter Property="DefaultLabelPosition" Value="Collapsed" />
     </Style>
   </ControlTheme>
-  <ControlTheme x:Key="{x:Type NavigationPage}" TargetType="NavigationPage"
-                BasedOn="{StaticResource MaterialNavigationPage}" />
+  <ControlTheme x:Key="{x:Type NavigationPage}" TargetType="NavigationPage"  BasedOn="{StaticResource MaterialNavigationPage}" />
 </ResourceDictionary>

--- a/Material.Styles/Resources/Themes/SplitView.axaml
+++ b/Material.Styles/Resources/Themes/SplitView.axaml
@@ -16,7 +16,6 @@
         <ControlTemplate>
           <Grid Name="Container" Background="{TemplateBinding Background}">
             <Grid.ColumnDefinitions>
-              <!-- why is this throwing a binding error? -->
               <ColumnDefinition
                 Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.PaneColumnGridLength}" />
               <ColumnDefinition Width="*" />
@@ -32,10 +31,10 @@
                          HorizontalAlignment="Right" />
             </Panel>
 
-            <Panel Name="ContentRoot">
+            <Panel Name="ContentRoot" Grid.Column="1">
               <ContentPresenter x:Name="PART_ContentPresenter" Content="{TemplateBinding Content}"
                                 ContentTemplate="{TemplateBinding ContentTemplate}" />
-              <Rectangle Name="LightDismissLayer" />
+              <Rectangle Name="LightDismissLayer" IsVisible="False" />
             </Panel>
 
           </Grid>
@@ -47,8 +46,7 @@
     <Style Selector="^:overlay:left /template/ Panel#PART_PaneRoot">
       <Setter Property="Width"
               Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ClosedPaneWidth}" />
-      <!-- ColumnSpan should be 2 -->
-      <Setter Property="Grid.ColumnSpan" Value="1" />
+      <Setter Property="Grid.ColumnSpan" Value="2" />
       <Setter Property="Grid.Column" Value="0" />
     </Style>
     <Style Selector="^:overlay:left /template/ Panel#ContentRoot">
@@ -70,8 +68,7 @@
 
     <!-- CompactOverlay -->
     <Style Selector="^:compactoverlay:left /template/ Panel#PART_PaneRoot">
-      <!-- ColumnSpan should be 2 -->
-      <Setter Property="Grid.ColumnSpan" Value="1" />
+      <Setter Property="Grid.ColumnSpan" Value="2" />
       <Setter Property="Grid.Column" Value="0" />
       <Setter Property="Width"
               Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ClosedPaneWidth}" />
@@ -115,10 +112,10 @@
                          Width="1" HorizontalAlignment="Left" />
             </Panel>
 
-            <Panel Name="ContentRoot">
+            <Panel Name="ContentRoot" Grid.Column="0">
               <ContentPresenter x:Name="PART_ContentPresenter" Content="{TemplateBinding Content}"
                                 ContentTemplate="{TemplateBinding ContentTemplate}" />
-              <Rectangle Name="LightDismissLayer" />
+              <Rectangle Name="LightDismissLayer" IsVisible="False" />
             </Panel>
 
           </Grid>
@@ -174,8 +171,182 @@
       <Setter Property="Grid.ColumnSpan" Value="1" />
     </Style>
 
+    <!-- Top -->
+    <Style Selector="^:top">
+      <Setter Property="Template">
+        <ControlTemplate>
+          <Grid Name="Container" Background="{TemplateBinding Background}">
+            <Grid.RowDefinitions>
+              <RowDefinition Height="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.PaneRowGridLength}" />
+              <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+
+            <Panel Name="PART_PaneRoot"
+                   Background="{TemplateBinding PaneBackground}"
+                   ClipToBounds="True"
+                   VerticalAlignment="Top"
+                   ZIndex="100">
+              <ContentPresenter x:Name="PART_PanePresenter"
+                                Content="{TemplateBinding Pane}"
+                                ContentTemplate="{TemplateBinding PaneTemplate}" />
+              <Rectangle Name="HCPaneBorder"
+                         Fill="{DynamicResource SystemControlForegroundTransparentBrush}"
+                         Height="1"
+                         VerticalAlignment="Bottom" />
+            </Panel>
+
+            <Panel Name="ContentRoot" Grid.Row="1">
+              <ContentPresenter x:Name="PART_ContentPresenter"
+                                Content="{TemplateBinding Content}"
+                                ContentTemplate="{TemplateBinding ContentTemplate}" />
+              <Rectangle Name="LightDismissLayer" IsVisible="False" />
+            </Panel>
+          </Grid>
+        </ControlTemplate>
+      </Setter>
+    </Style>
+
+    <!-- Overlay -->
+    <Style Selector="^:overlay:top /template/ Panel#PART_PaneRoot">
+      <Setter Property="Height"
+              Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ClosedPaneHeight}" />
+      <Setter Property="Grid.RowSpan" Value="1" />
+      <Setter Property="Grid.Row" Value="0" />
+    </Style>
+    <Style Selector="^:overlay:top /template/ Panel#ContentRoot">
+      <Setter Property="Grid.Row" Value="1" />
+      <Setter Property="Grid.RowSpan" Value="2" />
+    </Style>
+
+    <!-- CompactInline -->
+    <Style Selector="^:compactinline:top /template/ Panel#PART_PaneRoot">
+      <Setter Property="Grid.RowSpan" Value="1" />
+      <Setter Property="Grid.Row" Value="0" />
+      <Setter Property="Height"
+              Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ClosedPaneHeight}" />
+    </Style>
+    <Style Selector="^:compactinline:top /template/ Panel#ContentRoot">
+      <Setter Property="Grid.Row" Value="1" />
+      <Setter Property="Grid.RowSpan" Value="1" />
+    </Style>
+
+    <!-- CompactOverlay -->
+    <Style Selector="^:compactoverlay:top /template/ Panel#PART_PaneRoot">
+      <Setter Property="Grid.RowSpan" Value="1" />
+      <Setter Property="Grid.Row" Value="0" />
+      <Setter Property="Height"
+              Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ClosedPaneHeight}" />
+    </Style>
+    <Style Selector="^:compactoverlay:top /template/ Panel#ContentRoot">
+      <Setter Property="Grid.Row" Value="1" />
+      <Setter Property="Grid.RowSpan" Value="1" />
+    </Style>
+
+    <!-- Inline -->
+    <Style Selector="^:inline:top /template/ Panel#PART_PaneRoot">
+      <Setter Property="Grid.RowSpan" Value="1" />
+      <Setter Property="Grid.Row" Value="0" />
+      <Setter Property="Height"
+              Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ClosedPaneHeight}" />
+    </Style>
+    <Style Selector="^:inline:top /template/ Panel#ContentRoot">
+      <Setter Property="Grid.Row" Value="1" />
+      <Setter Property="Grid.RowSpan" Value="1" />
+    </Style>
+
+    <!-- Bottom -->
+    <Style Selector="^:bottom">
+      <Setter Property="Template">
+        <ControlTemplate>
+          <Grid Name="Container" Background="{TemplateBinding Background}">
+            <Grid.RowDefinitions>
+              <RowDefinition Height="*" />
+              <RowDefinition Height="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.PaneRowGridLength}" />
+            </Grid.RowDefinitions>
+
+            <Panel Name="PART_PaneRoot"
+                   Background="{TemplateBinding PaneBackground}"
+                   ClipToBounds="True"
+                   VerticalAlignment="Bottom"
+                   ZIndex="100">
+              <ContentPresenter x:Name="PART_PanePresenter"
+                                Content="{TemplateBinding Pane}"
+                                ContentTemplate="{TemplateBinding PaneTemplate}" />
+              <Rectangle Name="HCPaneBorder"
+                         Fill="{DynamicResource SystemControlForegroundTransparentBrush}"
+                         Height="1"
+                         VerticalAlignment="Top" />
+            </Panel>
+
+            <Panel Name="ContentRoot" Grid.Row="0">
+              <ContentPresenter x:Name="PART_ContentPresenter"
+                                Content="{TemplateBinding Content}"
+                                ContentTemplate="{TemplateBinding ContentTemplate}" />
+              <Rectangle Name="LightDismissLayer" IsVisible="False" />
+            </Panel>
+          </Grid>
+        </ControlTemplate>
+      </Setter>
+    </Style>
+
+    <!-- Overlay -->
+    <Style Selector="^:overlay:bottom /template/ Panel#PART_PaneRoot">
+      <Setter Property="Height"
+              Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ClosedPaneHeight}" />
+      <Setter Property="Grid.RowSpan" Value="2" />
+      <Setter Property="Grid.Row" Value="1" />
+    </Style>
+    <Style Selector="^:overlay:bottom /template/ Panel#ContentRoot">
+      <Setter Property="Grid.Row" Value="0" />
+      <Setter Property="Grid.RowSpan" Value="2" />
+    </Style>
+
+    <!-- CompactInline -->
+    <Style Selector="^:compactinline:bottom /template/ Panel#PART_PaneRoot">
+      <Setter Property="Grid.RowSpan" Value="1" />
+      <Setter Property="Grid.Row" Value="1" />
+      <Setter Property="Height"
+              Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ClosedPaneHeight}" />
+    </Style>
+    <Style Selector="^:compactinline:bottom /template/ Panel#ContentRoot">
+      <Setter Property="Grid.Row" Value="0" />
+      <Setter Property="Grid.RowSpan" Value="1" />
+    </Style>
+
+    <!-- CompactOverlay -->
+    <Style Selector="^:compactoverlay:bottom /template/ Panel#PART_PaneRoot">
+      <Setter Property="Grid.RowSpan" Value="2" />
+      <Setter Property="Grid.Row" Value="1" />
+      <Setter Property="Height"
+              Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ClosedPaneHeight}" />
+    </Style>
+    <Style Selector="^:compactoverlay:bottom /template/ Panel#ContentRoot">
+      <Setter Property="Grid.Row" Value="0" />
+      <Setter Property="Grid.RowSpan" Value="1" />
+    </Style>
+
+    <!-- Inline -->
+    <Style Selector="^:inline:bottom /template/ Panel#PART_PaneRoot">
+      <Setter Property="Grid.RowSpan" Value="1" />
+      <Setter Property="Grid.Row" Value="1" />
+      <Setter Property="Height"
+              Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ClosedPaneHeight}" />
+    </Style>
+    <Style Selector="^:inline:bottom /template/ Panel#ContentRoot">
+      <Setter Property="Grid.Row" Value="0" />
+      <Setter Property="Grid.RowSpan" Value="1" />
+    </Style>
+
     <!-- Open/Close Pane animation  -->
-    <Style Selector="^:open /template/ Panel#PART_PaneRoot">
+    <Style Selector="^:left:open /template/ Panel#PART_PaneRoot">
+      <Setter Property="Transitions">
+        <Transitions>
+          <DoubleTransition Property="Width" Duration="00:00:00.2" Easing="0.1,0.9,0.2,1.0" />
+        </Transitions>
+      </Setter>
+      <Setter Property="Width" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=OpenPaneLength}" />
+    </Style>
+    <Style Selector="^:right:open /template/ Panel#PART_PaneRoot">
       <Setter Property="Transitions">
         <Transitions>
           <DoubleTransition Property="Width" Duration="00:00:00.2" Easing="0.1,0.9,0.2,1.0" />
@@ -192,7 +363,7 @@
       <Setter Property="Opacity" Value="1.0" />
     </Style>
 
-    <Style Selector="^:closed /template/ Panel#PART_PaneRoot">
+    <Style Selector="^:left:closed /template/ Panel#PART_PaneRoot">
       <Setter Property="Transitions">
         <Transitions>
           <DoubleTransition Property="Width" Duration="00:00:00.1" Easing="0.1,0.9,0.2,1.0" />
@@ -200,6 +371,49 @@
       </Setter>
       <Setter Property="Width"
               Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ClosedPaneWidth}" />
+    </Style>
+    <Style Selector="^:right:closed /template/ Panel#PART_PaneRoot">
+      <Setter Property="Transitions">
+        <Transitions>
+          <DoubleTransition Property="Width" Duration="00:00:00.1" Easing="0.1,0.9,0.2,1.0" />
+        </Transitions>
+      </Setter>
+      <Setter Property="Width"
+              Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ClosedPaneWidth}" />
+    </Style>
+    <Style Selector="^:top:open /template/ Panel#PART_PaneRoot">
+      <Setter Property="Transitions">
+        <Transitions>
+          <DoubleTransition Property="Height" Duration="00:00:00.2" Easing="0.1,0.9,0.2,1.0" />
+        </Transitions>
+      </Setter>
+      <Setter Property="Height" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=OpenPaneLength}" />
+    </Style>
+    <Style Selector="^:bottom:open /template/ Panel#PART_PaneRoot">
+      <Setter Property="Transitions">
+        <Transitions>
+          <DoubleTransition Property="Height" Duration="00:00:00.2" Easing="0.1,0.9,0.2,1.0" />
+        </Transitions>
+      </Setter>
+      <Setter Property="Height" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=OpenPaneLength}" />
+    </Style>
+    <Style Selector="^:top:closed /template/ Panel#PART_PaneRoot">
+      <Setter Property="Transitions">
+        <Transitions>
+          <DoubleTransition Property="Height" Duration="00:00:00.1" Easing="0.1,0.9,0.2,1.0" />
+        </Transitions>
+      </Setter>
+      <Setter Property="Height"
+              Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ClosedPaneHeight}" />
+    </Style>
+    <Style Selector="^:bottom:closed /template/ Panel#PART_PaneRoot">
+      <Setter Property="Transitions">
+        <Transitions>
+          <DoubleTransition Property="Height" Duration="00:00:00.1" Easing="0.1,0.9,0.2,1.0" />
+        </Transitions>
+      </Setter>
+      <Setter Property="Height"
+              Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ClosedPaneHeight}" />
     </Style>
     <Style Selector="^:closed /template/ Rectangle#LightDismissLayer">
       <Setter Property="Transitions">

--- a/Material.Styles/Resources/Themes/TabbedPage.axaml
+++ b/Material.Styles/Resources/Themes/TabbedPage.axaml
@@ -12,6 +12,7 @@
   <x:Double x:Key="MaterialTabbedPageTabItemSpacing">4</x:Double>
   <x:Double x:Key="MaterialTabbedPageIndicatorThickness">2</x:Double>
   <x:Double x:Key="MaterialTabbedPageVerticalPipeHeight">24</x:Double>
+  <x:Double x:Key="MaterialTabbedPageTabItemUnselectedOpacity">0.5</x:Double>
 
   <Thickness x:Key="MaterialTabbedPageTabItemPadding">16,8</Thickness>
 
@@ -23,7 +24,6 @@
         <DockPanel>
           <Border Name="PART_TabStrip"
                   Background="{TemplateBinding Background}"
-                  BoxShadow="0 2 4 0 #33000000"
                   DockPanel.Dock="{TemplateBinding TabStripPlacement}">
             <ItemsPresenter Name="PART_ItemsPresenter">
               <ItemsPresenter.ItemsPanel>
@@ -57,102 +57,46 @@
     <Setter Property="FontSize" Value="{DynamicResource MaterialTabbedPageTabItemFontSize}" />
     <Setter Property="FontWeight" Value="Medium" />
     <Setter Property="Background" Value="{DynamicResource MaterialTabbedPageTabItemBackgroundUnselected}" />
-    <Setter Property="Foreground" Value="{DynamicResource MaterialPrimaryMidForegroundBrush}" />
+    <Setter Property="TextBlock.Foreground" Value="{DynamicResource MaterialPrimaryMidForegroundBrush}" />
     <Setter Property="Padding" Value="{DynamicResource MaterialTabbedPageTabItemPadding}" />
     <Setter Property="MinHeight" Value="{DynamicResource MaterialTabbedPageTabItemMinHeight}" />
     <Setter Property="HorizontalContentAlignment" Value="Center" />
     <Setter Property="VerticalContentAlignment" Value="Center" />
-    <Setter Property="Opacity" Value="0.7" />
-    <Setter Property="IndicatorTemplate">
-      <DataTemplate>
-        <Border Background="{DynamicResource MaterialPrimaryMidForegroundBrush}"
-                HorizontalAlignment="Stretch"
-                VerticalAlignment="Stretch" />
-      </DataTemplate>
-    </Setter>
+    <Setter Property="Opacity" Value="{DynamicResource MaterialTabbedPageTabItemUnselectedOpacity}" />
     <Setter Property="Template">
       <ControlTemplate>
-        <Panel>
-          <Border Name="PART_LayoutRoot"
-                  Background="{TemplateBinding Background}"
-                  BorderBrush="{TemplateBinding BorderBrush}"
-                  BorderThickness="{TemplateBinding BorderThickness}"
-                  Padding="{TemplateBinding Padding}">
-            <StackPanel Name="PART_HeaderPanel"
-                        Spacing="{DynamicResource MaterialTabbedPageTabItemSpacing}"
-                        HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                        VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
-              <ContentPresenter Name="PART_IconPresenter"
-                                Content="{TemplateBinding Icon}"
-                                ContentTemplate="{TemplateBinding IconTemplate}"
-                                HorizontalAlignment="Center"
-                                IsVisible="{TemplateBinding Icon, Converter={x:Static ObjectConverters.IsNotNull}}"
-                                Width="{DynamicResource MaterialTabbedPageTabItemIconSize}"
-                                Height="{DynamicResource MaterialTabbedPageTabItemIconSize}" />
-              <ContentPresenter Name="PART_ContentPresenter"
-                                HorizontalAlignment="Center"
-                                HorizontalContentAlignment="Center"
-                                Content="{TemplateBinding Header}"
-                                ContentTemplate="{TemplateBinding HeaderTemplate}"
-                                FontFamily="{TemplateBinding FontFamily}"
-                                FontSize="{DynamicResource MaterialTabbedPageTabItemFontSize}"
-                                FontWeight="{TemplateBinding FontWeight}" />
-            </StackPanel>
-          </Border>
-          <ContentPresenter Name="PART_SelectedPipe"
-                            VerticalAlignment="Bottom"
-                            HorizontalAlignment="Stretch"
-                            HorizontalContentAlignment="Stretch"
-                            VerticalContentAlignment="Stretch"
-                            Content="{TemplateBinding DataContext}"
-                            ContentTemplate="{TemplateBinding IndicatorTemplate}"
-                            IsVisible="False" />
-        </Panel>
+        <Border Name="PART_LayoutRoot"
+                Background="{TemplateBinding Background}"
+                BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="{TemplateBinding BorderThickness}"
+                Padding="{TemplateBinding Padding}">
+          <StackPanel Name="PART_HeaderPanel"
+                      Spacing="{DynamicResource MaterialTabbedPageTabItemSpacing}"
+                      HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                      VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+            <ContentPresenter Name="PART_IconPresenter"
+                              Content="{TemplateBinding Icon}"
+                              ContentTemplate="{TemplateBinding IconTemplate}"
+                              HorizontalAlignment="Center"
+                              IsVisible="{TemplateBinding Icon, Converter={x:Static ObjectConverters.IsNotNull}}"
+                              Width="{DynamicResource MaterialTabbedPageTabItemIconSize}"
+                              Height="{DynamicResource MaterialTabbedPageTabItemIconSize}" />
+            <ContentPresenter Name="PART_ContentPresenter"
+                              HorizontalAlignment="Center"
+                              HorizontalContentAlignment="Center"
+                              Content="{TemplateBinding Header}"
+                              ContentTemplate="{TemplateBinding HeaderTemplate}"
+                              FontFamily="{TemplateBinding FontFamily}"
+                              FontSize="{DynamicResource MaterialTabbedPageTabItemFontSize}"
+                              FontWeight="{TemplateBinding FontWeight}" />
+          </StackPanel>
+        </Border>
       </ControlTemplate>
     </Setter>
 
     <!-- Selected -->
     <Style Selector="^:selected">
       <Setter Property="Opacity" Value="1" />
-    </Style>
-    <Style Selector="^:selected /template/ ContentPresenter#PART_SelectedPipe">
-      <Setter Property="IsVisible" Value="True" />
-    </Style>
-
-    <!-- Placement-specific pipe -->
-    <Style Selector="^[TabStripPlacement=Top] /template/ ContentPresenter#PART_SelectedPipe">
-      <Setter Property="VerticalAlignment" Value="Bottom" />
-      <Setter Property="Height" Value="{DynamicResource MaterialTabbedPageIndicatorThickness}" />
-    </Style>
-    <Style Selector="^[TabStripPlacement=Bottom] /template/ ContentPresenter#PART_SelectedPipe">
-      <Setter Property="VerticalAlignment" Value="Top" />
-      <Setter Property="Height" Value="{DynamicResource MaterialTabbedPageIndicatorThickness}" />
-    </Style>
-    <Style Selector="^[TabStripPlacement=Right]">
-      <Setter Property="IndicatorTemplate">
-        <DataTemplate>
-          <Border Background="{DynamicResource MaterialPrimaryMidForegroundBrush}"
-                  Width="{DynamicResource MaterialTabbedPageIndicatorThickness}"
-                  Height="{DynamicResource MaterialTabbedPageVerticalPipeHeight}" />
-        </DataTemplate>
-      </Setter>
-    </Style>
-    <Style Selector="^[TabStripPlacement=Right] /template/ ContentPresenter#PART_SelectedPipe">
-      <Setter Property="HorizontalAlignment" Value="Right" />
-      <Setter Property="VerticalAlignment" Value="Center" />
-    </Style>
-    <Style Selector="^[TabStripPlacement=Left]">
-      <Setter Property="IndicatorTemplate">
-        <DataTemplate>
-          <Border Background="{DynamicResource MaterialPrimaryMidForegroundBrush}"
-                  Width="{DynamicResource MaterialTabbedPageIndicatorThickness}"
-                  Height="{DynamicResource MaterialTabbedPageVerticalPipeHeight}" />
-        </DataTemplate>
-      </Setter>
-    </Style>
-    <Style Selector="^[TabStripPlacement=Left] /template/ ContentPresenter#PART_SelectedPipe">
-      <Setter Property="HorizontalAlignment" Value="Left" />
-      <Setter Property="VerticalAlignment" Value="Center" />
     </Style>
 
     <!-- Pointer over -->

--- a/Material.Styles/Resources/Themes/TabbedPage.axaml
+++ b/Material.Styles/Resources/Themes/TabbedPage.axaml
@@ -203,6 +203,5 @@
     </Setter>
   </ControlTheme>
 
-  <ControlTheme x:Key="{x:Type TabbedPage}" TargetType="TabbedPage"
-                BasedOn="{StaticResource MaterialTabbedPage}" />
+  <ControlTheme x:Key="{x:Type TabbedPage}" TargetType="TabbedPage" BasedOn="{StaticResource MaterialTabbedPage}" />
 </ResourceDictionary>

--- a/Material.Styles/Resources/Themes/TabbedPage.axaml
+++ b/Material.Styles/Resources/Themes/TabbedPage.axaml
@@ -1,5 +1,6 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:assists="clr-namespace:Material.Styles.Assists">
   <!-- Material 2 TabbedPage resources -->
   <SolidColorBrush x:Key="MaterialTabbedPageTabItemBackgroundUnselected" Color="Transparent" />
   <SolidColorBrush x:Key="MaterialTabbedPageTabItemBackgroundSelected" Color="Transparent" />
@@ -24,7 +25,8 @@
         <DockPanel>
           <Border Name="PART_TabStrip"
                   Background="{TemplateBinding Background}"
-                  DockPanel.Dock="{TemplateBinding TabStripPlacement}">
+                  DockPanel.Dock="{TemplateBinding TabStripPlacement}"
+                  ZIndex="1">
             <ItemsPresenter Name="PART_ItemsPresenter">
               <ItemsPresenter.ItemsPanel>
                 <ItemsPanelTemplate>
@@ -50,6 +52,18 @@
       <Setter Property="Rows" Value="0" />
       <Setter Property="Columns" Value="1" />
     </Style>
+    <Style Selector="^[TabStripPlacement=Top] /template/ Border#PART_TabStrip">
+      <Setter Property="BoxShadow" Value="1.5 1.5 8 0 #4C000000" />
+    </Style>
+    <Style Selector="^[TabStripPlacement=Bottom] /template/ Border#PART_TabStrip">
+      <Setter Property="BoxShadow" Value="1.5 -1.5 8 0 #4C000000" />
+    </Style>
+    <Style Selector="^[TabStripPlacement=Left] /template/ Border#PART_TabStrip">
+      <Setter Property="BoxShadow" Value="1.5 1.5 8 0 #4C000000" />
+    </Style>
+    <Style Selector="^[TabStripPlacement=Right] /template/ Border#PART_TabStrip">
+      <Setter Property="BoxShadow" Value="-1.5 1.5 8 0 #4C000000" />
+    </Style>
   </ControlTheme>
 
   <!-- TabbedPage TabItem theme -->
@@ -63,40 +77,101 @@
     <Setter Property="HorizontalContentAlignment" Value="Center" />
     <Setter Property="VerticalContentAlignment" Value="Center" />
     <Setter Property="Opacity" Value="{DynamicResource MaterialTabbedPageTabItemUnselectedOpacity}" />
+    <Setter Property="IndicatorTemplate">
+      <DataTemplate>
+        <Border Background="{DynamicResource MaterialPrimaryMidForegroundBrush}"
+                HorizontalAlignment="Stretch"
+                VerticalAlignment="Stretch" />
+      </DataTemplate>
+    </Setter>
     <Setter Property="Template">
       <ControlTemplate>
-        <Border Name="PART_LayoutRoot"
-                Background="{TemplateBinding Background}"
-                BorderBrush="{TemplateBinding BorderBrush}"
-                BorderThickness="{TemplateBinding BorderThickness}"
-                Padding="{TemplateBinding Padding}">
-          <StackPanel Name="PART_HeaderPanel"
-                      Spacing="{DynamicResource MaterialTabbedPageTabItemSpacing}"
-                      HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                      VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
-            <ContentPresenter Name="PART_IconPresenter"
-                              Content="{TemplateBinding Icon}"
-                              ContentTemplate="{TemplateBinding IconTemplate}"
-                              HorizontalAlignment="Center"
-                              IsVisible="{TemplateBinding Icon, Converter={x:Static ObjectConverters.IsNotNull}}"
-                              Width="{DynamicResource MaterialTabbedPageTabItemIconSize}"
-                              Height="{DynamicResource MaterialTabbedPageTabItemIconSize}" />
-            <ContentPresenter Name="PART_ContentPresenter"
-                              HorizontalAlignment="Center"
-                              HorizontalContentAlignment="Center"
-                              Content="{TemplateBinding Header}"
-                              ContentTemplate="{TemplateBinding HeaderTemplate}"
-                              FontFamily="{TemplateBinding FontFamily}"
-                              FontSize="{DynamicResource MaterialTabbedPageTabItemFontSize}"
-                              FontWeight="{TemplateBinding FontWeight}" />
-          </StackPanel>
-        </Border>
+        <Panel>
+          <Border Name="PART_LayoutRoot"
+                  Background="{TemplateBinding Background}"
+                  BorderBrush="{TemplateBinding BorderBrush}"
+                  BorderThickness="{TemplateBinding BorderThickness}"
+                  Padding="{TemplateBinding Padding}">
+            <StackPanel Name="PART_HeaderPanel"
+                        Spacing="{DynamicResource MaterialTabbedPageTabItemSpacing}"
+                        HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                        VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+              <ContentPresenter Name="PART_IconPresenter"
+                                Content="{TemplateBinding Icon}"
+                                HorizontalAlignment="Center"
+                                IsVisible="{TemplateBinding Icon, Converter={x:Static ObjectConverters.IsNotNull}}"
+                                Width="{DynamicResource MaterialTabbedPageTabItemIconSize}"
+                                Height="{DynamicResource MaterialTabbedPageTabItemIconSize}">
+                <ContentPresenter.ContentTemplate>
+                  <DataTemplate DataType="Geometry">
+                    <Viewbox Stretch="Uniform">
+                      <Path Data="{Binding}" Fill="{DynamicResource MaterialPrimaryMidForegroundBrush}" />
+                    </Viewbox>
+                  </DataTemplate>
+                </ContentPresenter.ContentTemplate>
+              </ContentPresenter>
+              <ContentPresenter Name="PART_ContentPresenter"
+                                HorizontalAlignment="Center"
+                                HorizontalContentAlignment="Center"
+                                Content="{TemplateBinding Header}"
+                                ContentTemplate="{TemplateBinding HeaderTemplate}"
+                                FontFamily="{TemplateBinding FontFamily}"
+                                FontSize="{DynamicResource MaterialTabbedPageTabItemFontSize}"
+                                FontWeight="{TemplateBinding FontWeight}" />
+            </StackPanel>
+          </Border>
+          <ContentPresenter Name="PART_SelectedPipe"
+                            VerticalAlignment="Bottom"
+                            HorizontalAlignment="Stretch"
+                            HorizontalContentAlignment="Stretch"
+                            VerticalContentAlignment="Stretch"
+                            Content="{TemplateBinding DataContext}"
+                            ContentTemplate="{TemplateBinding IndicatorTemplate}"
+                            IsVisible="False" />
+        </Panel>
       </ControlTemplate>
     </Setter>
 
     <!-- Selected -->
     <Style Selector="^:selected">
       <Setter Property="Opacity" Value="1" />
+    </Style>
+    <Style Selector="^:selected /template/ ContentPresenter#PART_SelectedPipe">
+      <Setter Property="IsVisible" Value="True" />
+    </Style>
+    <Style Selector="^[TabStripPlacement=Top] /template/ ContentPresenter#PART_SelectedPipe">
+      <Setter Property="VerticalAlignment" Value="Bottom" />
+      <Setter Property="Height" Value="{DynamicResource MaterialTabbedPageIndicatorThickness}" />
+    </Style>
+    <Style Selector="^[TabStripPlacement=Bottom] /template/ ContentPresenter#PART_SelectedPipe">
+      <Setter Property="VerticalAlignment" Value="Top" />
+      <Setter Property="Height" Value="{DynamicResource MaterialTabbedPageIndicatorThickness}" />
+    </Style>
+    <Style Selector="^[TabStripPlacement=Right]">
+      <Setter Property="IndicatorTemplate">
+        <DataTemplate>
+          <Border Background="{DynamicResource MaterialPrimaryMidForegroundBrush}"
+                  Width="{DynamicResource MaterialTabbedPageIndicatorThickness}"
+                  Height="{DynamicResource MaterialTabbedPageVerticalPipeHeight}" />
+        </DataTemplate>
+      </Setter>
+    </Style>
+    <Style Selector="^[TabStripPlacement=Right] /template/ ContentPresenter#PART_SelectedPipe">
+      <Setter Property="HorizontalAlignment" Value="Right" />
+      <Setter Property="VerticalAlignment" Value="Center" />
+    </Style>
+    <Style Selector="^[TabStripPlacement=Left]">
+      <Setter Property="IndicatorTemplate">
+        <DataTemplate>
+          <Border Background="{DynamicResource MaterialPrimaryMidForegroundBrush}"
+                  Width="{DynamicResource MaterialTabbedPageIndicatorThickness}"
+                  Height="{DynamicResource MaterialTabbedPageVerticalPipeHeight}" />
+        </DataTemplate>
+      </Setter>
+    </Style>
+    <Style Selector="^[TabStripPlacement=Left] /template/ ContentPresenter#PART_SelectedPipe">
+      <Setter Property="HorizontalAlignment" Value="Left" />
+      <Setter Property="VerticalAlignment" Value="Center" />
     </Style>
 
     <!-- Pointer over -->

--- a/Material.Styles/Resources/Themes/TabbedPage.axaml
+++ b/Material.Styles/Resources/Themes/TabbedPage.axaml
@@ -1,0 +1,189 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  <!-- Material 2 TabbedPage resources -->
+  <SolidColorBrush x:Key="MaterialTabbedPageTabItemBackgroundUnselected" Color="Transparent" />
+  <SolidColorBrush x:Key="MaterialTabbedPageTabItemBackgroundSelected" Color="Transparent" />
+  <SolidColorBrush x:Key="MaterialTabbedPageTabItemBackgroundPointerOver" Color="#0A000000" />
+  <SolidColorBrush x:Key="MaterialTabbedPageTabItemBackgroundPressed" Color="#14000000" />
+
+  <x:Double x:Key="MaterialTabbedPageTabItemMinHeight">48</x:Double>
+  <x:Double x:Key="MaterialTabbedPageTabItemIconSize">24</x:Double>
+  <x:Double x:Key="MaterialTabbedPageTabItemFontSize">14</x:Double>
+  <x:Double x:Key="MaterialTabbedPageTabItemSpacing">4</x:Double>
+  <x:Double x:Key="MaterialTabbedPageIndicatorThickness">2</x:Double>
+  <x:Double x:Key="MaterialTabbedPageVerticalPipeHeight">24</x:Double>
+
+  <Thickness x:Key="MaterialTabbedPageTabItemPadding">16,8</Thickness>
+
+  <!-- TabbedPage TabControl theme -->
+  <ControlTheme x:Key="MaterialTabbedPageTabControlTheme" TargetType="TabControl">
+    <Setter Property="Background" Value="{DynamicResource MaterialPrimaryMidBrush}" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <DockPanel>
+          <Border Name="PART_TabStrip"
+                  Background="{TemplateBinding Background}"
+                  BoxShadow="0 2 4 0 #33000000"
+                  DockPanel.Dock="{TemplateBinding TabStripPlacement}">
+            <ItemsPresenter Name="PART_ItemsPresenter">
+              <ItemsPresenter.ItemsPanel>
+                <ItemsPanelTemplate>
+                  <UniformGrid Rows="1" />
+                </ItemsPanelTemplate>
+              </ItemsPresenter.ItemsPanel>
+            </ItemsPresenter>
+          </Border>
+          <Panel ClipToBounds="True">
+            <ContentPresenter Name="PART_SelectedContentHost2"
+                              HorizontalContentAlignment="Stretch"
+                              VerticalContentAlignment="Stretch"
+                              IsVisible="False" />
+            <ContentPresenter Name="PART_SelectedContentHost"
+                              HorizontalContentAlignment="Stretch"
+                              VerticalContentAlignment="Stretch" />
+          </Panel>
+        </DockPanel>
+      </ControlTemplate>
+    </Setter>
+    <Style Selector="^[TabStripPlacement=Left] /template/ ItemsPresenter#PART_ItemsPresenter > UniformGrid,
+           ^[TabStripPlacement=Right] /template/ ItemsPresenter#PART_ItemsPresenter > UniformGrid">
+      <Setter Property="Rows" Value="0" />
+      <Setter Property="Columns" Value="1" />
+    </Style>
+  </ControlTheme>
+
+  <!-- TabbedPage TabItem theme -->
+  <ControlTheme x:Key="MaterialTabbedPageTabItemTheme" TargetType="TabItem">
+    <Setter Property="FontSize" Value="{DynamicResource MaterialTabbedPageTabItemFontSize}" />
+    <Setter Property="FontWeight" Value="Medium" />
+    <Setter Property="Background" Value="{DynamicResource MaterialTabbedPageTabItemBackgroundUnselected}" />
+    <Setter Property="Foreground" Value="{DynamicResource MaterialPrimaryMidForegroundBrush}" />
+    <Setter Property="Padding" Value="{DynamicResource MaterialTabbedPageTabItemPadding}" />
+    <Setter Property="MinHeight" Value="{DynamicResource MaterialTabbedPageTabItemMinHeight}" />
+    <Setter Property="HorizontalContentAlignment" Value="Center" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="Opacity" Value="0.7" />
+    <Setter Property="IndicatorTemplate">
+      <DataTemplate>
+        <Border Background="{DynamicResource MaterialPrimaryMidForegroundBrush}"
+                HorizontalAlignment="Stretch"
+                VerticalAlignment="Stretch" />
+      </DataTemplate>
+    </Setter>
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Panel>
+          <Border Name="PART_LayoutRoot"
+                  Background="{TemplateBinding Background}"
+                  BorderBrush="{TemplateBinding BorderBrush}"
+                  BorderThickness="{TemplateBinding BorderThickness}"
+                  Padding="{TemplateBinding Padding}">
+            <StackPanel Name="PART_HeaderPanel"
+                        Spacing="{DynamicResource MaterialTabbedPageTabItemSpacing}"
+                        HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                        VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+              <ContentPresenter Name="PART_IconPresenter"
+                                Content="{TemplateBinding Icon}"
+                                ContentTemplate="{TemplateBinding IconTemplate}"
+                                HorizontalAlignment="Center"
+                                IsVisible="{TemplateBinding Icon, Converter={x:Static ObjectConverters.IsNotNull}}"
+                                Width="{DynamicResource MaterialTabbedPageTabItemIconSize}"
+                                Height="{DynamicResource MaterialTabbedPageTabItemIconSize}" />
+              <ContentPresenter Name="PART_ContentPresenter"
+                                HorizontalAlignment="Center"
+                                HorizontalContentAlignment="Center"
+                                Content="{TemplateBinding Header}"
+                                ContentTemplate="{TemplateBinding HeaderTemplate}"
+                                FontFamily="{TemplateBinding FontFamily}"
+                                FontSize="{DynamicResource MaterialTabbedPageTabItemFontSize}"
+                                FontWeight="{TemplateBinding FontWeight}" />
+            </StackPanel>
+          </Border>
+          <ContentPresenter Name="PART_SelectedPipe"
+                            VerticalAlignment="Bottom"
+                            HorizontalAlignment="Stretch"
+                            HorizontalContentAlignment="Stretch"
+                            VerticalContentAlignment="Stretch"
+                            Content="{TemplateBinding DataContext}"
+                            ContentTemplate="{TemplateBinding IndicatorTemplate}"
+                            IsVisible="False" />
+        </Panel>
+      </ControlTemplate>
+    </Setter>
+
+    <!-- Selected -->
+    <Style Selector="^:selected">
+      <Setter Property="Opacity" Value="1" />
+    </Style>
+    <Style Selector="^:selected /template/ ContentPresenter#PART_SelectedPipe">
+      <Setter Property="IsVisible" Value="True" />
+    </Style>
+
+    <!-- Placement-specific pipe -->
+    <Style Selector="^[TabStripPlacement=Top] /template/ ContentPresenter#PART_SelectedPipe">
+      <Setter Property="VerticalAlignment" Value="Bottom" />
+      <Setter Property="Height" Value="{DynamicResource MaterialTabbedPageIndicatorThickness}" />
+    </Style>
+    <Style Selector="^[TabStripPlacement=Bottom] /template/ ContentPresenter#PART_SelectedPipe">
+      <Setter Property="VerticalAlignment" Value="Top" />
+      <Setter Property="Height" Value="{DynamicResource MaterialTabbedPageIndicatorThickness}" />
+    </Style>
+    <Style Selector="^[TabStripPlacement=Right]">
+      <Setter Property="IndicatorTemplate">
+        <DataTemplate>
+          <Border Background="{DynamicResource MaterialPrimaryMidForegroundBrush}"
+                  Width="{DynamicResource MaterialTabbedPageIndicatorThickness}"
+                  Height="{DynamicResource MaterialTabbedPageVerticalPipeHeight}" />
+        </DataTemplate>
+      </Setter>
+    </Style>
+    <Style Selector="^[TabStripPlacement=Right] /template/ ContentPresenter#PART_SelectedPipe">
+      <Setter Property="HorizontalAlignment" Value="Right" />
+      <Setter Property="VerticalAlignment" Value="Center" />
+    </Style>
+    <Style Selector="^[TabStripPlacement=Left]">
+      <Setter Property="IndicatorTemplate">
+        <DataTemplate>
+          <Border Background="{DynamicResource MaterialPrimaryMidForegroundBrush}"
+                  Width="{DynamicResource MaterialTabbedPageIndicatorThickness}"
+                  Height="{DynamicResource MaterialTabbedPageVerticalPipeHeight}" />
+        </DataTemplate>
+      </Setter>
+    </Style>
+    <Style Selector="^[TabStripPlacement=Left] /template/ ContentPresenter#PART_SelectedPipe">
+      <Setter Property="HorizontalAlignment" Value="Left" />
+      <Setter Property="VerticalAlignment" Value="Center" />
+    </Style>
+
+    <!-- Pointer over -->
+    <Style Selector="^:pointerover /template/ Border#PART_LayoutRoot">
+      <Setter Property="Background" Value="{DynamicResource MaterialTabbedPageTabItemBackgroundPointerOver}" />
+    </Style>
+    <!-- Pressed -->
+    <Style Selector="^:pressed /template/ Border#PART_LayoutRoot">
+      <Setter Property="Background" Value="{DynamicResource MaterialTabbedPageTabItemBackgroundPressed}" />
+    </Style>
+    <!-- Disabled -->
+    <Style Selector="^:disabled">
+      <Setter Property="Opacity" Value="0.38" />
+    </Style>
+  </ControlTheme>
+
+  <ControlTheme x:Key="MaterialTabbedPage" TargetType="TabbedPage">
+    <Setter Property="Background" Value="{DynamicResource MaterialPaperBrush}" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Panel Background="{TemplateBinding Background}">
+          <TabControl Name="PART_TabControl"
+                      Theme="{StaticResource MaterialTabbedPageTabControlTheme}"
+                      ItemContainerTheme="{StaticResource MaterialTabbedPageTabItemTheme}"
+                      HorizontalAlignment="Stretch"
+                      VerticalAlignment="Stretch" />
+        </Panel>
+      </ControlTemplate>
+    </Setter>
+  </ControlTheme>
+
+  <ControlTheme x:Key="{x:Type TabbedPage}" TargetType="TabbedPage"
+                BasedOn="{StaticResource MaterialTabbedPage}" />
+</ResourceDictionary>


### PR DESCRIPTION
Added support for:

- TabbedPage
- ContentPage
- CarouselPage
- DrawerPage
- NavigationPage

#503 

Looked at the avalonia12 implementation of SimpleTheme and FluentTheme for the basic styling, then added material styling based on already defined styles in the repo. and looked at [https://m2.material.io/components?platform=android](https://m2.material.io/components?platform=android) for more styling improvements.

Added 'Pages' page to the demo app.

DrawerPage
<img width="2244" height="1264" alt="avalonia12drawerpage" src="https://github.com/user-attachments/assets/27b72334-b810-4289-9e0d-9e0e42427996" />

TabbedPage
<img width="2244" height="1264" alt="avalonia12tabbedpage" src="https://github.com/user-attachments/assets/c092e994-67f6-4314-9bef-86528e18aea0" />

NavigationPage
<img width="2244" height="1264" alt="avalonia12navpage" src="https://github.com/user-attachments/assets/24a10db6-7d63-4a37-a00c-a4d1a65af4bc" />


