### PR TITLE
Fixed new page brushes

### DIFF
--- a/Material.Styles/Resources/Themes/CarouselPage.axaml
+++ b/Material.Styles/Resources/Themes/CarouselPage.axaml
@@ -1,7 +1,7 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
   <ControlTheme x:Key="MaterialCarouselPage" TargetType="CarouselPage">
-    <Setter Property="Background" Value="{DynamicResource MaterialPaperBrush}" />
+    <Setter Property="Background" Value="Transparent" />
     <Setter Property="Template">
       <ControlTemplate>
         <Carousel Name="PART_Carousel"

--- a/Material.Styles/Resources/Themes/ContentPage.axaml
+++ b/Material.Styles/Resources/Themes/ContentPage.axaml
@@ -1,7 +1,7 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
   <ControlTheme x:Key="MaterialContentPage" TargetType="ContentPage">
-    <Setter Property="Background" Value="{DynamicResource MaterialPaperBrush}" />
+    <Setter Property="Background" Value="Transparent" />
     <Setter Property="Foreground" Value="{DynamicResource MaterialBodyBrush}" />
     <Setter Property="Template">
       <ControlTemplate>

--- a/Material.Styles/Resources/Themes/DrawerPage.axaml
+++ b/Material.Styles/Resources/Themes/DrawerPage.axaml
@@ -7,7 +7,7 @@
   <SolidColorBrush x:Key="MaterialDrawerBackgroundBrush" Color="{DynamicResource MaterialCardBackgroundColor}" />
 
   <ControlTheme x:Key="MaterialDrawerPage" TargetType="DrawerPage">
-    <Setter Property="Background" Value="{DynamicResource MaterialPaperBrush}" />
+    <Setter Property="Background" Value="Transparent" />
     <Setter Property="Foreground" Value="{DynamicResource MaterialBodyBrush}" />
     <Setter Property="DrawerBackground" Value="{DynamicResource MaterialDrawerBackgroundBrush}" />
     <Setter Property="Template">

--- a/Material.Styles/Resources/Themes/DrawerPage.axaml
+++ b/Material.Styles/Resources/Themes/DrawerPage.axaml
@@ -81,7 +81,7 @@
                                 Theme="{StaticResource MaterialFlatToggleButton}"
                                 IsChecked="{Binding #PART_SplitView.IsPaneOpen, Mode=TwoWay}"
                                 Background="Transparent"
-                                Foreground="{DynamicResource MaterialPrimaryMidForegroundBrush}"
+                                Foreground="{DynamicResource MaterialBodyBrush}"
                                 DockPanel.Dock="Left"
                                  AutomationProperties.Name="Toggle navigation drawer"
                                 ToolTip.Tip="Toggle navigation drawer">
@@ -89,7 +89,7 @@
                       <PathIcon
                         IsVisible="{Binding DrawerIcon, RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static ObjectConverters.IsNull}}"
                         Data="{DynamicResource MaterialDrawerPaneButtonIcon}"
-                        Foreground="{DynamicResource MaterialPrimaryMidForegroundBrush}"
+                        Foreground="{DynamicResource MaterialBodyBrush}"
                         HorizontalAlignment="Center"
                         VerticalAlignment="Center"/>
                       <ContentPresenter
@@ -104,7 +104,7 @@
                   <ContentPresenter x:Name="PART_TitlePresenter"
                                     Content="{TemplateBinding Header}"
                                     ContentTemplate="{TemplateBinding HeaderTemplate}"
-                                    Foreground="{DynamicResource MaterialPrimaryMidForegroundBrush}"
+                                    Foreground="{DynamicResource MaterialBodyBrush}"
                                     VerticalAlignment="Center"
                                     VerticalContentAlignment="Center"
                                     FontSize="20"
@@ -126,7 +126,7 @@
                                 Theme="{StaticResource MaterialFlatToggleButton}"
                                 IsChecked="{Binding #PART_SplitView.IsPaneOpen, Mode=TwoWay}"
                                 Background="Transparent"
-                                Foreground="{DynamicResource MaterialPrimaryMidForegroundBrush}"
+                                Foreground="{DynamicResource MaterialBodyBrush}"
                                 DockPanel.Dock="Left"
                                  AutomationProperties.Name="Toggle navigation drawer"
                                 ToolTip.Tip="Toggle navigation drawer">
@@ -134,7 +134,7 @@
                       <PathIcon
                         IsVisible="{Binding DrawerIcon, RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static ObjectConverters.IsNull}}"
                         Data="{DynamicResource MaterialDrawerPaneButtonIcon}"
-                        Foreground="{DynamicResource MaterialPrimaryMidForegroundBrush}"
+                        Foreground="{DynamicResource MaterialBodyBrush}"
                         HorizontalAlignment="Center"
                         VerticalAlignment="Center"/>
                       <ContentPresenter
@@ -149,7 +149,7 @@
                   <ContentPresenter x:Name="PART_BottomTitlePresenter"
                                     Content="{TemplateBinding Header}"
                                     ContentTemplate="{TemplateBinding HeaderTemplate}"
-                                    Foreground="{DynamicResource MaterialPrimaryMidForegroundBrush}"
+                                    Foreground="{DynamicResource MaterialBodyBrush}"
                                     VerticalAlignment="Center"
                                     VerticalContentAlignment="Center"
                                     FontSize="20"

--- a/Material.Styles/Resources/Themes/NavigationPage.axaml
+++ b/Material.Styles/Resources/Themes/NavigationPage.axaml
@@ -66,7 +66,7 @@
                       WindowDecorationProperties.ElementRole="DecorationsElement"
                       Theme="{StaticResource MaterialFlatButton}"
                       Background="Transparent"
-                      Foreground="{DynamicResource MaterialPrimaryMidForegroundBrush}"
+                      Foreground="{DynamicResource MaterialBodyBrush}"
                       IsVisible="{TemplateBinding IsBackButtonEffectivelyVisible}"
                       VerticalAlignment="Stretch"
                       Padding="8,0"
@@ -74,7 +74,7 @@
                 <Panel Background="Transparent">
                   <Path Data="{DynamicResource MaterialNavigationPageBackIcon}"
                         x:Name="PART_BackButtonDefaultIcon"
-                        Fill="{DynamicResource MaterialPrimaryMidForegroundBrush}"
+                        Fill="{DynamicResource MaterialBodyBrush}"
                         Width="24"
                         Height="24"
                         Stretch="Uniform"
@@ -90,7 +90,7 @@
                                 Grid.Column="1"
                                 FontSize="20"
                                 FontWeight="Medium"
-                                Foreground="{DynamicResource MaterialPrimaryMidForegroundBrush}"
+                                Foreground="{DynamicResource MaterialBodyBrush}"
                                 Content="{Binding CurrentPage?.Header, RelativeSource={RelativeSource TemplatedParent}, FallbackValue={x:Null}}"
                                 ContentTemplate="{Binding CurrentPage?.HeaderTemplate, RelativeSource={RelativeSource TemplatedParent}, FallbackValue={x:Null}}"
                                 VerticalAlignment="Center"
@@ -101,7 +101,7 @@
                                 Grid.Column="2"
                                 HorizontalAlignment="Right"
                                 VerticalContentAlignment="Stretch"
-                                Foreground="{DynamicResource MaterialPrimaryMidForegroundBrush}"
+                                Foreground="{DynamicResource MaterialBodyBrush}"
                                 Content="{Binding CurrentPage?.(NavigationPage.TopCommandBar), RelativeSource={RelativeSource TemplatedParent}, FallbackValue={x:Null}}" />
             </Grid>
           </Border>

--- a/Material.Styles/Resources/Themes/NavigationPage.axaml
+++ b/Material.Styles/Resources/Themes/NavigationPage.axaml
@@ -4,7 +4,7 @@
   <StreamGeometry x:Key="MaterialNavigationPageBackIcon">M12.7347,4.20949 C13.0332,3.92233 13.508,3.93153 13.7952,4.23005 C14.0823,4.52857 14.0731,5.00335 13.7746,5.29051 L5.50039,13.25 L24.2532,13.25 C24.6674,13.25 25.0032,13.5858 25.0032,13.9999982 C25.0032,14.4142 24.6674,14.75 24.2532,14.75 L5.50137,14.75 L13.7746,22.7085 C14.0731,22.9957 14.0823,23.4705 13.7952,23.769 C13.508,24.0675 13.0332,24.0767 12.7347,23.7896 L3.30673,14.7202 C2.89776,14.3268 2.89776,13.6723 3.30673,13.2788 L12.7347,4.20949 Z</StreamGeometry>
 
   <ControlTheme x:Key="MaterialNavigationPage" TargetType="NavigationPage">
-    <Setter Property="Background" Value="{DynamicResource MaterialPaperBrush}" />
+    <Setter Property="Background" Value="Transparent" />
     <Setter Property="PageTransition">
       <Setter.Value>
         <PageSlide Duration="0:0:0.3" Orientation="Horizontal" FillMode="Forward">

--- a/Material.Styles/Resources/Themes/TabbedPage.axaml
+++ b/Material.Styles/Resources/Themes/TabbedPage.axaml
@@ -20,6 +20,7 @@
   <!-- TabbedPage TabControl theme -->
   <ControlTheme x:Key="MaterialTabbedPageTabControlTheme" TargetType="TabControl">
     <Setter Property="Background" Value="{DynamicResource MaterialPrimaryMidBrush}" />
+    <Setter Property="TextElement.Foreground" Value="{DynamicResource MaterialBodyBrush}" />
     <Setter Property="Template">
       <ControlTemplate>
         <DockPanel>
@@ -71,7 +72,7 @@
     <Setter Property="FontSize" Value="{DynamicResource MaterialTabbedPageTabItemFontSize}" />
     <Setter Property="FontWeight" Value="Medium" />
     <Setter Property="Background" Value="{DynamicResource MaterialTabbedPageTabItemBackgroundUnselected}" />
-    <Setter Property="TextBlock.Foreground" Value="{DynamicResource MaterialPrimaryMidForegroundBrush}" />
+    <Setter Property="TextBlock.Foreground" Value="{Binding (TextElement.Foreground), RelativeSource={RelativeSource AncestorType=TabControl}}" />
     <Setter Property="Padding" Value="{DynamicResource MaterialTabbedPageTabItemPadding}" />
     <Setter Property="MinHeight" Value="{DynamicResource MaterialTabbedPageTabItemMinHeight}" />
     <Setter Property="HorizontalContentAlignment" Value="Center" />
@@ -79,7 +80,7 @@
     <Setter Property="Opacity" Value="{DynamicResource MaterialTabbedPageTabItemUnselectedOpacity}" />
     <Setter Property="IndicatorTemplate">
       <DataTemplate>
-        <Border Background="{DynamicResource MaterialPrimaryMidForegroundBrush}"
+        <Border Background="{Binding (TextElement.Foreground), RelativeSource={RelativeSource AncestorType=TabControl}}"
                 HorizontalAlignment="Stretch"
                 VerticalAlignment="Stretch" />
       </DataTemplate>
@@ -105,7 +106,7 @@
                 <ContentPresenter.ContentTemplate>
                   <DataTemplate DataType="Geometry">
                     <Viewbox Stretch="Uniform">
-                      <Path Data="{Binding}" Fill="{DynamicResource MaterialPrimaryMidForegroundBrush}" />
+                      <Path Data="{Binding}" Fill="{Binding (TextElement.Foreground), RelativeSource={RelativeSource AncestorType=TabControl}}" />
                     </Viewbox>
                   </DataTemplate>
                 </ContentPresenter.ContentTemplate>
@@ -150,7 +151,7 @@
     <Style Selector="^[TabStripPlacement=Right]">
       <Setter Property="IndicatorTemplate">
         <DataTemplate>
-          <Border Background="{DynamicResource MaterialPrimaryMidForegroundBrush}"
+          <Border Background="{Binding (TextElement.Foreground), RelativeSource={RelativeSource AncestorType=TabControl}}"
                   Width="{DynamicResource MaterialTabbedPageIndicatorThickness}"
                   Height="{DynamicResource MaterialTabbedPageVerticalPipeHeight}" />
         </DataTemplate>
@@ -163,7 +164,7 @@
     <Style Selector="^[TabStripPlacement=Left]">
       <Setter Property="IndicatorTemplate">
         <DataTemplate>
-          <Border Background="{DynamicResource MaterialPrimaryMidForegroundBrush}"
+          <Border Background="{Binding (TextElement.Foreground), RelativeSource={RelativeSource AncestorType=TabControl}}"
                   Width="{DynamicResource MaterialTabbedPageIndicatorThickness}"
                   Height="{DynamicResource MaterialTabbedPageVerticalPipeHeight}" />
         </DataTemplate>

--- a/Material.Styles/Resources/Themes/TabbedPage.axaml
+++ b/Material.Styles/Resources/Themes/TabbedPage.axaml
@@ -189,7 +189,7 @@
   </ControlTheme>
 
   <ControlTheme x:Key="MaterialTabbedPage" TargetType="TabbedPage">
-    <Setter Property="Background" Value="{DynamicResource MaterialPaperBrush}" />
+    <Setter Property="Background" Value="Transparent" />
     <Setter Property="Template">
       <ControlTemplate>
         <Panel Background="{TemplateBinding Background}">


### PR DESCRIPTION
Removed the background that where set in the pages. 
So now ExperimentalAcrylicBorder can work fine with the new avalonia 12 pages

Also set the foregrounds of the topbar elements to be in par with the windowdecorations. 
The problem was that the windowdecorations would change color when switching themes but the topbar elements (header and pane button etc.) of the page would not change.