### PR TITLE
Removes LeftDrawerExpandThresholdWidth to prevent auto opening ignoring the IsOpened

### DIFF
--- a/Material.Avalonia.Demo/MainView.axaml
+++ b/Material.Avalonia.Demo/MainView.axaml
@@ -38,7 +38,7 @@
 
   <dialogHostAvalonia:DialogHost Identifier="MainDialogHost">
     <controls:SnackbarHost HostName="Root" TemplateApplied="TemplatedControl_OnTemplateApplied">
-      <controls:NavigationDrawer Name="LeftDrawer" Classes="permanent"
+      <controls:NavigationDrawer Name="LeftDrawer" Classes="permanent" LeftDrawerExpandThresholdWidth="1000"
                                  LeftDrawerOpened="{Binding ElementName=NavDrawerSwitch, Path=IsChecked, Mode=TwoWay}">
         <controls:NavigationDrawer.LeftDrawerContent>
           <ScrollViewer>

--- a/Material.Styles/Controls/NavigationDrawer.axaml
+++ b/Material.Styles/Controls/NavigationDrawer.axaml
@@ -16,7 +16,6 @@
     <Setter Property="Background" Value="Transparent" />
     <Setter Property="LeftDrawerWidth" Value="320" />
     <Setter Property="RightDrawerWidth" Value="320" />
-    <Setter Property="LeftDrawerExpandThresholdWidth" Value="1000" />
     <Setter Property="Template">
       <ControlTemplate>
         <Border Name="PART_RootBorder"


### PR DESCRIPTION
Fixes #517 
removed LeftDrawerExpandThresholdWidth from control style, user can still use it explicitly in the navigationdrawer. 
this property prevented starting with a closed drawer as the LeftDrawerExpandThresholdWidth  would override it when window exceeds 1000 width.